### PR TITLE
Investigate badge color implementation

### DIFF
--- a/CineCraze/app/scr/main/java/com/cinecraze/free/stream/CarouselAdapter.java
+++ b/CineCraze/app/scr/main/java/com/cinecraze/free/stream/CarouselAdapter.java
@@ -55,7 +55,7 @@ public class CarouselAdapter extends RecyclerView.Adapter<CarouselAdapter.ViewHo
         setCategoryBadge(holder.categoryBadge, entry.getSubCategory());
         
         // Set type badge (below info) - Content type badge
-        setTypeBadge(holder.typeBadge, entry.getMainCategory());
+        setTypeBadge(holder.typeBadge, entry.getSubCategory());
 
         holder.playButton.setOnClickListener(v -> {
             DetailsActivity.start(context, entry, allEntries);
@@ -114,7 +114,7 @@ public class CarouselAdapter extends RecyclerView.Adapter<CarouselAdapter.ViewHo
             category = "Other";
         }
         
-        // Determine badge text and color based on content type
+        // Determine badge text and color based on content type from subCategory
         if (category.toLowerCase().contains("movie") || category.toLowerCase().contains("film")) {
             badgeText = "MOVIE";
             badgeColor = ContextCompat.getColor(context, R.color.type_badge_movies); // Light blue
@@ -125,11 +125,21 @@ public class CarouselAdapter extends RecyclerView.Adapter<CarouselAdapter.ViewHo
             badgeText = "LIVE";
             badgeColor = ContextCompat.getColor(context, R.color.type_badge_live); // Red
         } else {
-            badgeText = category.toUpperCase();
-            if (badgeText.length() > 6) {
-                badgeText = badgeText.substring(0, 6);
+            // If no specific content type found, try to infer from the category
+            String lowerCategory = category.toLowerCase();
+            if (lowerCategory.contains("action") || lowerCategory.contains("drama") || 
+                lowerCategory.contains("comedy") || lowerCategory.contains("horror") ||
+                lowerCategory.contains("romance") || lowerCategory.contains("thriller")) {
+                // This looks like a movie genre, so it's likely a movie
+                badgeText = "MOVIE";
+                badgeColor = ContextCompat.getColor(context, R.color.type_badge_movies);
+            } else {
+                badgeText = category.toUpperCase();
+                if (badgeText.length() > 6) {
+                    badgeText = badgeText.substring(0, 6);
+                }
+                badgeColor = ContextCompat.getColor(context, R.color.type_badge_default); // Orange
             }
-            badgeColor = ContextCompat.getColor(context, R.color.type_badge_default); // Orange
         }
         
         badge.setText(badgeText);

--- a/CineCraze/app/scr/main/java/com/cinecraze/free/stream/CarouselAdapter.java
+++ b/CineCraze/app/scr/main/java/com/cinecraze/free/stream/CarouselAdapter.java
@@ -55,7 +55,7 @@ public class CarouselAdapter extends RecyclerView.Adapter<CarouselAdapter.ViewHo
         setCategoryBadge(holder.categoryBadge, entry.getSubCategory());
         
         // Set type badge (below info) - Content type badge
-        setTypeBadge(holder.typeBadge, entry.getSubCategory());
+        setTypeBadge(holder.typeBadge, entry.getMainCategory());
 
         holder.playButton.setOnClickListener(v -> {
             DetailsActivity.start(context, entry, allEntries);
@@ -114,7 +114,7 @@ public class CarouselAdapter extends RecyclerView.Adapter<CarouselAdapter.ViewHo
             category = "Other";
         }
         
-        // Determine badge text and color based on content type from subCategory
+        // Determine badge text and color based on content type from mainCategory
         if (category.toLowerCase().contains("movie") || category.toLowerCase().contains("film")) {
             badgeText = "MOVIE";
             badgeColor = ContextCompat.getColor(context, R.color.type_badge_movies); // Light blue
@@ -125,21 +125,11 @@ public class CarouselAdapter extends RecyclerView.Adapter<CarouselAdapter.ViewHo
             badgeText = "LIVE";
             badgeColor = ContextCompat.getColor(context, R.color.type_badge_live); // Red
         } else {
-            // If no specific content type found, try to infer from the category
-            String lowerCategory = category.toLowerCase();
-            if (lowerCategory.contains("action") || lowerCategory.contains("drama") || 
-                lowerCategory.contains("comedy") || lowerCategory.contains("horror") ||
-                lowerCategory.contains("romance") || lowerCategory.contains("thriller")) {
-                // This looks like a movie genre, so it's likely a movie
-                badgeText = "MOVIE";
-                badgeColor = ContextCompat.getColor(context, R.color.type_badge_movies);
-            } else {
-                badgeText = category.toUpperCase();
-                if (badgeText.length() > 6) {
-                    badgeText = badgeText.substring(0, 6);
-                }
-                badgeColor = ContextCompat.getColor(context, R.color.type_badge_default); // Orange
+            badgeText = category.toUpperCase();
+            if (badgeText.length() > 6) {
+                badgeText = badgeText.substring(0, 6);
             }
+            badgeColor = ContextCompat.getColor(context, R.color.type_badge_default); // Orange
         }
         
         badge.setText(badgeText);

--- a/CineCraze/app/scr/main/java/com/cinecraze/free/stream/CarouselAdapter.java
+++ b/CineCraze/app/scr/main/java/com/cinecraze/free/stream/CarouselAdapter.java
@@ -115,15 +115,17 @@ public class CarouselAdapter extends RecyclerView.Adapter<CarouselAdapter.ViewHo
         }
         
         // Determine badge text and color based on content type from mainCategory
-        if (category.toLowerCase().contains("movie") || category.toLowerCase().contains("film")) {
-            badgeText = "MOVIE";
-            badgeColor = ContextCompat.getColor(context, R.color.type_badge_movies); // Light blue
-        } else if (category.toLowerCase().contains("series") || category.toLowerCase().contains("tv")) {
-            badgeText = "SERIES";
-            badgeColor = ContextCompat.getColor(context, R.color.type_badge_series); // Green
-        } else if (category.toLowerCase().contains("live")) {
+        String lowerCategory = category.toLowerCase();
+        
+        if (lowerCategory.contains("live")) {
             badgeText = "LIVE";
             badgeColor = ContextCompat.getColor(context, R.color.type_badge_live); // Red
+        } else if (lowerCategory.contains("movie") || lowerCategory.contains("film")) {
+            badgeText = "MOVIE";
+            badgeColor = ContextCompat.getColor(context, R.color.type_badge_movies); // Light blue
+        } else if (lowerCategory.contains("series") || lowerCategory.contains("tv")) {
+            badgeText = "SERIES";
+            badgeColor = ContextCompat.getColor(context, R.color.type_badge_series); // Green
         } else {
             badgeText = category.toUpperCase();
             if (badgeText.length() > 6) {

--- a/CineCraze/app/scr/main/java/com/cinecraze/free/stream/CarouselAdapter.java
+++ b/CineCraze/app/scr/main/java/com/cinecraze/free/stream/CarouselAdapter.java
@@ -51,11 +51,11 @@ public class CarouselAdapter extends RecyclerView.Adapter<CarouselAdapter.ViewHo
         holder.duration.setText(entry.getDuration());
         Glide.with(context).load(entry.getPoster()).into(holder.poster);
         
-        // Set category badge (on poster)
+        // Set category badge (on poster) - Genre badge
         setCategoryBadge(holder.categoryBadge, entry.getSubCategory());
         
-        // Set type badge (below info)
-        setTypeBadge(holder.typeBadge, entry.getSubCategory());
+        // Set type badge (below info) - Content type badge
+        setTypeBadge(holder.typeBadge, entry.getMainCategory());
 
         holder.playButton.setOnClickListener(v -> {
             DetailsActivity.start(context, entry, allEntries);
@@ -75,22 +75,25 @@ public class CarouselAdapter extends RecyclerView.Adapter<CarouselAdapter.ViewHo
             category = "Other";
         }
         
-        // Determine badge text and color based on category
-        if (category.toLowerCase().contains("movie") || category.toLowerCase().contains("film")) {
-            badgeText = "MOVIE";
-            badgeColor = ContextCompat.getColor(context, R.color.badge_movies);
-        } else if (category.toLowerCase().contains("series") || category.toLowerCase().contains("tv")) {
-            badgeText = "SERIES";
-            badgeColor = ContextCompat.getColor(context, R.color.badge_series);
-        } else if (category.toLowerCase().contains("live") || category.toLowerCase().contains("tv")) {
-            badgeText = "LIVE TV";
-            badgeColor = ContextCompat.getColor(context, R.color.badge_live_tv);
+        // For genre badge, use the category as-is and apply genre-specific colors
+        badgeText = category.toUpperCase();
+        if (badgeText.length() > 8) {
+            badgeText = badgeText.substring(0, 8);
+        }
+        
+        // Apply genre-specific colors
+        if (category.toLowerCase().contains("action")) {
+            badgeColor = ContextCompat.getColor(context, R.color.badge_live_tv); // Red for action
+        } else if (category.toLowerCase().contains("drama")) {
+            badgeColor = ContextCompat.getColor(context, R.color.badge_series); // Green for drama
+        } else if (category.toLowerCase().contains("comedy")) {
+            badgeColor = ContextCompat.getColor(context, R.color.badge_movies); // Light blue for comedy
+        } else if (category.toLowerCase().contains("horror")) {
+            badgeColor = ContextCompat.getColor(context, R.color.badge_live_tv); // Red for horror
+        } else if (category.toLowerCase().contains("romance")) {
+            badgeColor = ContextCompat.getColor(context, R.color.badge_series); // Green for romance
         } else {
-            badgeText = category.toUpperCase();
-            if (badgeText.length() > 8) {
-                badgeText = badgeText.substring(0, 8);
-            }
-            badgeColor = ContextCompat.getColor(context, R.color.badge_default);
+            badgeColor = ContextCompat.getColor(context, R.color.badge_default); // Default orange
         }
         
         badge.setText(badgeText);
@@ -111,22 +114,22 @@ public class CarouselAdapter extends RecyclerView.Adapter<CarouselAdapter.ViewHo
             category = "Other";
         }
         
-        // Determine badge text and color based on category
+        // Determine badge text and color based on content type
         if (category.toLowerCase().contains("movie") || category.toLowerCase().contains("film")) {
             badgeText = "MOVIE";
-            badgeColor = ContextCompat.getColor(context, R.color.type_badge_movies);
+            badgeColor = ContextCompat.getColor(context, R.color.type_badge_movies); // Light blue
         } else if (category.toLowerCase().contains("series") || category.toLowerCase().contains("tv")) {
             badgeText = "SERIES";
-            badgeColor = ContextCompat.getColor(context, R.color.type_badge_series);
+            badgeColor = ContextCompat.getColor(context, R.color.type_badge_series); // Green
         } else if (category.toLowerCase().contains("live")) {
             badgeText = "LIVE";
-            badgeColor = ContextCompat.getColor(context, R.color.type_badge_live);
+            badgeColor = ContextCompat.getColor(context, R.color.type_badge_live); // Red
         } else {
             badgeText = category.toUpperCase();
             if (badgeText.length() > 6) {
                 badgeText = badgeText.substring(0, 6);
             }
-            badgeColor = ContextCompat.getColor(context, R.color.type_badge_default);
+            badgeColor = ContextCompat.getColor(context, R.color.type_badge_default); // Orange
         }
         
         badge.setText(badgeText);

--- a/CineCraze/app/scr/main/java/com/cinecraze/free/stream/MovieAdapter.java
+++ b/CineCraze/app/scr/main/java/com/cinecraze/free/stream/MovieAdapter.java
@@ -75,14 +75,14 @@ public class MovieAdapter extends RecyclerView.Adapter<MovieAdapter.ViewHolder> 
             holder.duration.setText(entry.getDuration());
         }
         
-        // Set category badge (on poster)
+        // Set category badge (on poster) - Genre badge
         if (holder.categoryBadge != null) {
             setCategoryBadge(holder.categoryBadge, entry.getSubCategory());
         }
         
-        // Set type badge (below title)
+        // Set type badge (below title) - Content type badge
         if (holder.typeBadge != null) {
-            setTypeBadge(holder.typeBadge, entry.getSubCategory());
+            setTypeBadge(holder.typeBadge, entry.getMainCategory());
         }
 
         holder.itemView.setOnClickListener(v -> {
@@ -107,22 +107,25 @@ public class MovieAdapter extends RecyclerView.Adapter<MovieAdapter.ViewHolder> 
             category = "Other";
         }
         
-        // Determine badge text and color based on category
-        if (category.toLowerCase().contains("movie") || category.toLowerCase().contains("film")) {
-            badgeText = "MOVIE";
-            badgeColor = ContextCompat.getColor(context, R.color.badge_movies);
-        } else if (category.toLowerCase().contains("series") || category.toLowerCase().contains("tv")) {
-            badgeText = "SERIES";
-            badgeColor = ContextCompat.getColor(context, R.color.badge_series);
-        } else if (category.toLowerCase().contains("live") || category.toLowerCase().contains("tv")) {
-            badgeText = "LIVE TV";
-            badgeColor = ContextCompat.getColor(context, R.color.badge_live_tv);
+        // For genre badge, use the category as-is and apply genre-specific colors
+        badgeText = category.toUpperCase();
+        if (badgeText.length() > 8) {
+            badgeText = badgeText.substring(0, 8);
+        }
+        
+        // Apply genre-specific colors
+        if (category.toLowerCase().contains("action")) {
+            badgeColor = ContextCompat.getColor(context, R.color.badge_live_tv); // Red for action
+        } else if (category.toLowerCase().contains("drama")) {
+            badgeColor = ContextCompat.getColor(context, R.color.badge_series); // Green for drama
+        } else if (category.toLowerCase().contains("comedy")) {
+            badgeColor = ContextCompat.getColor(context, R.color.badge_movies); // Light blue for comedy
+        } else if (category.toLowerCase().contains("horror")) {
+            badgeColor = ContextCompat.getColor(context, R.color.badge_live_tv); // Red for horror
+        } else if (category.toLowerCase().contains("romance")) {
+            badgeColor = ContextCompat.getColor(context, R.color.badge_series); // Green for romance
         } else {
-            badgeText = category.toUpperCase();
-            if (badgeText.length() > 8) {
-                badgeText = badgeText.substring(0, 8);
-            }
-            badgeColor = ContextCompat.getColor(context, R.color.badge_default);
+            badgeColor = ContextCompat.getColor(context, R.color.badge_default); // Default orange
         }
         
         badge.setText(badgeText);
@@ -143,22 +146,22 @@ public class MovieAdapter extends RecyclerView.Adapter<MovieAdapter.ViewHolder> 
             category = "Other";
         }
         
-        // Determine badge text and color based on category
+        // Determine badge text and color based on content type
         if (category.toLowerCase().contains("movie") || category.toLowerCase().contains("film")) {
             badgeText = "MOVIE";
-            badgeColor = ContextCompat.getColor(context, R.color.type_badge_movies);
+            badgeColor = ContextCompat.getColor(context, R.color.type_badge_movies); // Light blue
         } else if (category.toLowerCase().contains("series") || category.toLowerCase().contains("tv")) {
             badgeText = "SERIES";
-            badgeColor = ContextCompat.getColor(context, R.color.type_badge_series);
+            badgeColor = ContextCompat.getColor(context, R.color.type_badge_series); // Green
         } else if (category.toLowerCase().contains("live")) {
             badgeText = "LIVE";
-            badgeColor = ContextCompat.getColor(context, R.color.type_badge_live);
+            badgeColor = ContextCompat.getColor(context, R.color.type_badge_live); // Red
         } else {
             badgeText = category.toUpperCase();
             if (badgeText.length() > 6) {
                 badgeText = badgeText.substring(0, 6);
             }
-            badgeColor = ContextCompat.getColor(context, R.color.type_badge_default);
+            badgeColor = ContextCompat.getColor(context, R.color.type_badge_default); // Orange
         }
         
         badge.setText(badgeText);

--- a/CineCraze/app/scr/main/java/com/cinecraze/free/stream/MovieAdapter.java
+++ b/CineCraze/app/scr/main/java/com/cinecraze/free/stream/MovieAdapter.java
@@ -147,15 +147,17 @@ public class MovieAdapter extends RecyclerView.Adapter<MovieAdapter.ViewHolder> 
         }
         
         // Determine badge text and color based on content type from mainCategory
-        if (category.toLowerCase().contains("movie") || category.toLowerCase().contains("film")) {
-            badgeText = "MOVIE";
-            badgeColor = ContextCompat.getColor(context, R.color.type_badge_movies); // Light blue
-        } else if (category.toLowerCase().contains("series") || category.toLowerCase().contains("tv")) {
-            badgeText = "SERIES";
-            badgeColor = ContextCompat.getColor(context, R.color.type_badge_series); // Green
-        } else if (category.toLowerCase().contains("live")) {
+        String lowerCategory = category.toLowerCase();
+        
+        if (lowerCategory.contains("live")) {
             badgeText = "LIVE";
             badgeColor = ContextCompat.getColor(context, R.color.type_badge_live); // Red
+        } else if (lowerCategory.contains("movie") || lowerCategory.contains("film")) {
+            badgeText = "MOVIE";
+            badgeColor = ContextCompat.getColor(context, R.color.type_badge_movies); // Light blue
+        } else if (lowerCategory.contains("series") || lowerCategory.contains("tv")) {
+            badgeText = "SERIES";
+            badgeColor = ContextCompat.getColor(context, R.color.type_badge_series); // Green
         } else {
             badgeText = category.toUpperCase();
             if (badgeText.length() > 6) {

--- a/CineCraze/app/scr/main/java/com/cinecraze/free/stream/MovieAdapter.java
+++ b/CineCraze/app/scr/main/java/com/cinecraze/free/stream/MovieAdapter.java
@@ -82,7 +82,7 @@ public class MovieAdapter extends RecyclerView.Adapter<MovieAdapter.ViewHolder> 
         
         // Set type badge (below title) - Content type badge
         if (holder.typeBadge != null) {
-            setTypeBadge(holder.typeBadge, entry.getMainCategory());
+            setTypeBadge(holder.typeBadge, entry.getSubCategory());
         }
 
         holder.itemView.setOnClickListener(v -> {
@@ -146,7 +146,7 @@ public class MovieAdapter extends RecyclerView.Adapter<MovieAdapter.ViewHolder> 
             category = "Other";
         }
         
-        // Determine badge text and color based on content type
+        // Determine badge text and color based on content type from subCategory
         if (category.toLowerCase().contains("movie") || category.toLowerCase().contains("film")) {
             badgeText = "MOVIE";
             badgeColor = ContextCompat.getColor(context, R.color.type_badge_movies); // Light blue
@@ -157,11 +157,21 @@ public class MovieAdapter extends RecyclerView.Adapter<MovieAdapter.ViewHolder> 
             badgeText = "LIVE";
             badgeColor = ContextCompat.getColor(context, R.color.type_badge_live); // Red
         } else {
-            badgeText = category.toUpperCase();
-            if (badgeText.length() > 6) {
-                badgeText = badgeText.substring(0, 6);
+            // If no specific content type found, try to infer from the category
+            String lowerCategory = category.toLowerCase();
+            if (lowerCategory.contains("action") || lowerCategory.contains("drama") || 
+                lowerCategory.contains("comedy") || lowerCategory.contains("horror") ||
+                lowerCategory.contains("romance") || lowerCategory.contains("thriller")) {
+                // This looks like a movie genre, so it's likely a movie
+                badgeText = "MOVIE";
+                badgeColor = ContextCompat.getColor(context, R.color.type_badge_movies);
+            } else {
+                badgeText = category.toUpperCase();
+                if (badgeText.length() > 6) {
+                    badgeText = badgeText.substring(0, 6);
+                }
+                badgeColor = ContextCompat.getColor(context, R.color.type_badge_default); // Orange
             }
-            badgeColor = ContextCompat.getColor(context, R.color.type_badge_default); // Orange
         }
         
         badge.setText(badgeText);

--- a/CineCraze/app/scr/main/java/com/cinecraze/free/stream/MovieAdapter.java
+++ b/CineCraze/app/scr/main/java/com/cinecraze/free/stream/MovieAdapter.java
@@ -82,7 +82,7 @@ public class MovieAdapter extends RecyclerView.Adapter<MovieAdapter.ViewHolder> 
         
         // Set type badge (below title) - Content type badge
         if (holder.typeBadge != null) {
-            setTypeBadge(holder.typeBadge, entry.getSubCategory());
+            setTypeBadge(holder.typeBadge, entry.getMainCategory());
         }
 
         holder.itemView.setOnClickListener(v -> {
@@ -146,7 +146,7 @@ public class MovieAdapter extends RecyclerView.Adapter<MovieAdapter.ViewHolder> 
             category = "Other";
         }
         
-        // Determine badge text and color based on content type from subCategory
+        // Determine badge text and color based on content type from mainCategory
         if (category.toLowerCase().contains("movie") || category.toLowerCase().contains("film")) {
             badgeText = "MOVIE";
             badgeColor = ContextCompat.getColor(context, R.color.type_badge_movies); // Light blue
@@ -157,21 +157,11 @@ public class MovieAdapter extends RecyclerView.Adapter<MovieAdapter.ViewHolder> 
             badgeText = "LIVE";
             badgeColor = ContextCompat.getColor(context, R.color.type_badge_live); // Red
         } else {
-            // If no specific content type found, try to infer from the category
-            String lowerCategory = category.toLowerCase();
-            if (lowerCategory.contains("action") || lowerCategory.contains("drama") || 
-                lowerCategory.contains("comedy") || lowerCategory.contains("horror") ||
-                lowerCategory.contains("romance") || lowerCategory.contains("thriller")) {
-                // This looks like a movie genre, so it's likely a movie
-                badgeText = "MOVIE";
-                badgeColor = ContextCompat.getColor(context, R.color.type_badge_movies);
-            } else {
-                badgeText = category.toUpperCase();
-                if (badgeText.length() > 6) {
-                    badgeText = badgeText.substring(0, 6);
-                }
-                badgeColor = ContextCompat.getColor(context, R.color.type_badge_default); // Orange
+            badgeText = category.toUpperCase();
+            if (badgeText.length() > 6) {
+                badgeText = badgeText.substring(0, 6);
             }
+            badgeColor = ContextCompat.getColor(context, R.color.type_badge_default); // Orange
         }
         
         badge.setText(badgeText);

--- a/CineCraze/app/scr/main/java/com/cinecraze/free/stream/PaginatedMovieAdapter.java
+++ b/CineCraze/app/scr/main/java/com/cinecraze/free/stream/PaginatedMovieAdapter.java
@@ -252,15 +252,17 @@ public class PaginatedMovieAdapter extends RecyclerView.Adapter<RecyclerView.Vie
         }
         
         // Determine badge text and color based on content type from mainCategory
-        if (category.toLowerCase().contains("movie") || category.toLowerCase().contains("film")) {
-            badgeText = "MOVIE";
-            badgeColor = ContextCompat.getColor(context, R.color.type_badge_movies); // Light blue
-        } else if (category.toLowerCase().contains("series") || category.toLowerCase().contains("tv")) {
-            badgeText = "SERIES";
-            badgeColor = ContextCompat.getColor(context, R.color.type_badge_series); // Green
-        } else if (category.toLowerCase().contains("live")) {
+        String lowerCategory = category.toLowerCase();
+        
+        if (lowerCategory.contains("live")) {
             badgeText = "LIVE";
             badgeColor = ContextCompat.getColor(context, R.color.type_badge_live); // Red
+        } else if (lowerCategory.contains("movie") || lowerCategory.contains("film")) {
+            badgeText = "MOVIE";
+            badgeColor = ContextCompat.getColor(context, R.color.type_badge_movies); // Light blue
+        } else if (lowerCategory.contains("series") || lowerCategory.contains("tv")) {
+            badgeText = "SERIES";
+            badgeColor = ContextCompat.getColor(context, R.color.type_badge_series); // Green
         } else {
             badgeText = category.toUpperCase();
             if (badgeText.length() > 6) {

--- a/CineCraze/app/scr/main/java/com/cinecraze/free/stream/PaginatedMovieAdapter.java
+++ b/CineCraze/app/scr/main/java/com/cinecraze/free/stream/PaginatedMovieAdapter.java
@@ -2,6 +2,7 @@ package com.cinecraze.free.stream;
 
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.drawable.GradientDrawable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -11,6 +12,7 @@ import android.widget.RatingBar;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.bumptech.glide.Glide;
@@ -121,6 +123,16 @@ public class PaginatedMovieAdapter extends RecyclerView.Adapter<RecyclerView.Vie
                 movieHolder.duration.setText(entry.getDuration());
             }
 
+            // Set category badge (on poster) - Genre badge
+            if (movieHolder.categoryBadge != null) {
+                setCategoryBadge(movieHolder.categoryBadge, entry.getSubCategory());
+            }
+            
+            // Set type badge (below title) - Content type badge
+            if (movieHolder.typeBadge != null) {
+                setTypeBadge(movieHolder.typeBadge, entry.getMainCategory());
+            }
+
             movieHolder.itemView.setOnClickListener(v -> {
                 Intent intent = new Intent(context, DetailsActivity.class);
                 intent.putExtra("entry", new Gson().toJson(entry));
@@ -162,6 +174,8 @@ public class PaginatedMovieAdapter extends RecyclerView.Adapter<RecyclerView.Vie
         TextView year;
         TextView country;
         TextView duration;
+        TextView categoryBadge; // Added for category badge
+        TextView typeBadge; // Added for type badge
 
         public MovieViewHolder(@NonNull View itemView) {
             super(itemView);
@@ -172,6 +186,8 @@ public class PaginatedMovieAdapter extends RecyclerView.Adapter<RecyclerView.Vie
             year = itemView.findViewById(R.id.year);
             country = itemView.findViewById(R.id.country);
             duration = itemView.findViewById(R.id.duration);
+            categoryBadge = itemView.findViewById(R.id.category_badge); // Initialize categoryBadge
+            typeBadge = itemView.findViewById(R.id.type_badge); // Initialize typeBadge
         }
     }
     
@@ -184,5 +200,82 @@ public class PaginatedMovieAdapter extends RecyclerView.Adapter<RecyclerView.Vie
             previousButton = itemView.findViewById(R.id.btn_previous);
             nextButton = itemView.findViewById(R.id.btn_next);
         }
+    }
+
+    // Helper method to set category badge (genre badge)
+    private void setCategoryBadge(TextView badge, String category) {
+        String badgeText;
+        int badgeColor;
+        
+        if (category == null || category.trim().isEmpty()) {
+            category = "Other";
+        }
+        
+        // For genre badge, use the category as-is and apply genre-specific colors
+        badgeText = category.toUpperCase();
+        if (badgeText.length() > 8) {
+            badgeText = badgeText.substring(0, 8);
+        }
+        
+        // Apply genre-specific colors
+        if (category.toLowerCase().contains("action")) {
+            badgeColor = ContextCompat.getColor(context, R.color.badge_live_tv); // Red for action
+        } else if (category.toLowerCase().contains("drama")) {
+            badgeColor = ContextCompat.getColor(context, R.color.badge_series); // Green for drama
+        } else if (category.toLowerCase().contains("comedy")) {
+            badgeColor = ContextCompat.getColor(context, R.color.badge_movies); // Light blue for comedy
+        } else if (category.toLowerCase().contains("horror")) {
+            badgeColor = ContextCompat.getColor(context, R.color.badge_live_tv); // Red for horror
+        } else if (category.toLowerCase().contains("romance")) {
+            badgeColor = ContextCompat.getColor(context, R.color.badge_series); // Green for romance
+        } else {
+            badgeColor = ContextCompat.getColor(context, R.color.badge_default); // Default orange
+        }
+        
+        badge.setText(badgeText);
+        
+        // Create colored background
+        GradientDrawable background = new GradientDrawable();
+        background.setShape(GradientDrawable.RECTANGLE);
+        background.setColor(badgeColor);
+        background.setCornerRadius(4 * context.getResources().getDisplayMetrics().density);
+        badge.setBackground(background);
+    }
+
+    // Helper method to set type badge (content type badge)
+    private void setTypeBadge(TextView badge, String category) {
+        String badgeText;
+        int badgeColor;
+        
+        if (category == null || category.trim().isEmpty()) {
+            category = "Other";
+        }
+        
+        // Determine badge text and color based on content type
+        if (category.toLowerCase().contains("movie") || category.toLowerCase().contains("film")) {
+            badgeText = "MOVIE";
+            badgeColor = ContextCompat.getColor(context, R.color.type_badge_movies); // Light blue
+        } else if (category.toLowerCase().contains("series") || category.toLowerCase().contains("tv")) {
+            badgeText = "SERIES";
+            badgeColor = ContextCompat.getColor(context, R.color.type_badge_series); // Green
+        } else if (category.toLowerCase().contains("live")) {
+            badgeText = "LIVE";
+            badgeColor = ContextCompat.getColor(context, R.color.type_badge_live); // Red
+        } else {
+            badgeText = category.toUpperCase();
+            if (badgeText.length() > 6) {
+                badgeText = badgeText.substring(0, 6);
+            }
+            badgeColor = ContextCompat.getColor(context, R.color.type_badge_default); // Orange
+        }
+        
+        badge.setText(badgeText);
+        
+        // Create colored background
+        GradientDrawable background = new GradientDrawable();
+        background.setShape(GradientDrawable.RECTANGLE);
+        background.setColor(badgeColor);
+        background.setCornerRadius(3 * context.getResources().getDisplayMetrics().density);
+        badge.setBackground(background);
     }
 }

--- a/CineCraze/app/scr/main/java/com/cinecraze/free/stream/PaginatedMovieAdapter.java
+++ b/CineCraze/app/scr/main/java/com/cinecraze/free/stream/PaginatedMovieAdapter.java
@@ -130,7 +130,7 @@ public class PaginatedMovieAdapter extends RecyclerView.Adapter<RecyclerView.Vie
             
             // Set type badge (below title) - Content type badge
             if (movieHolder.typeBadge != null) {
-                setTypeBadge(movieHolder.typeBadge, entry.getMainCategory());
+                setTypeBadge(movieHolder.typeBadge, entry.getSubCategory());
             }
 
             movieHolder.itemView.setOnClickListener(v -> {
@@ -251,7 +251,7 @@ public class PaginatedMovieAdapter extends RecyclerView.Adapter<RecyclerView.Vie
             category = "Other";
         }
         
-        // Determine badge text and color based on content type
+        // Determine badge text and color based on content type from subCategory
         if (category.toLowerCase().contains("movie") || category.toLowerCase().contains("film")) {
             badgeText = "MOVIE";
             badgeColor = ContextCompat.getColor(context, R.color.type_badge_movies); // Light blue
@@ -262,11 +262,21 @@ public class PaginatedMovieAdapter extends RecyclerView.Adapter<RecyclerView.Vie
             badgeText = "LIVE";
             badgeColor = ContextCompat.getColor(context, R.color.type_badge_live); // Red
         } else {
-            badgeText = category.toUpperCase();
-            if (badgeText.length() > 6) {
-                badgeText = badgeText.substring(0, 6);
+            // If no specific content type found, try to infer from the category
+            String lowerCategory = category.toLowerCase();
+            if (lowerCategory.contains("action") || lowerCategory.contains("drama") || 
+                lowerCategory.contains("comedy") || lowerCategory.contains("horror") ||
+                lowerCategory.contains("romance") || lowerCategory.contains("thriller")) {
+                // This looks like a movie genre, so it's likely a movie
+                badgeText = "MOVIE";
+                badgeColor = ContextCompat.getColor(context, R.color.type_badge_movies);
+            } else {
+                badgeText = category.toUpperCase();
+                if (badgeText.length() > 6) {
+                    badgeText = badgeText.substring(0, 6);
+                }
+                badgeColor = ContextCompat.getColor(context, R.color.type_badge_default); // Orange
             }
-            badgeColor = ContextCompat.getColor(context, R.color.type_badge_default); // Orange
         }
         
         badge.setText(badgeText);

--- a/CineCraze/app/scr/main/java/com/cinecraze/free/stream/PaginatedMovieAdapter.java
+++ b/CineCraze/app/scr/main/java/com/cinecraze/free/stream/PaginatedMovieAdapter.java
@@ -130,7 +130,7 @@ public class PaginatedMovieAdapter extends RecyclerView.Adapter<RecyclerView.Vie
             
             // Set type badge (below title) - Content type badge
             if (movieHolder.typeBadge != null) {
-                setTypeBadge(movieHolder.typeBadge, entry.getSubCategory());
+                setTypeBadge(movieHolder.typeBadge, entry.getMainCategory());
             }
 
             movieHolder.itemView.setOnClickListener(v -> {
@@ -251,7 +251,7 @@ public class PaginatedMovieAdapter extends RecyclerView.Adapter<RecyclerView.Vie
             category = "Other";
         }
         
-        // Determine badge text and color based on content type from subCategory
+        // Determine badge text and color based on content type from mainCategory
         if (category.toLowerCase().contains("movie") || category.toLowerCase().contains("film")) {
             badgeText = "MOVIE";
             badgeColor = ContextCompat.getColor(context, R.color.type_badge_movies); // Light blue
@@ -262,21 +262,11 @@ public class PaginatedMovieAdapter extends RecyclerView.Adapter<RecyclerView.Vie
             badgeText = "LIVE";
             badgeColor = ContextCompat.getColor(context, R.color.type_badge_live); // Red
         } else {
-            // If no specific content type found, try to infer from the category
-            String lowerCategory = category.toLowerCase();
-            if (lowerCategory.contains("action") || lowerCategory.contains("drama") || 
-                lowerCategory.contains("comedy") || lowerCategory.contains("horror") ||
-                lowerCategory.contains("romance") || lowerCategory.contains("thriller")) {
-                // This looks like a movie genre, so it's likely a movie
-                badgeText = "MOVIE";
-                badgeColor = ContextCompat.getColor(context, R.color.type_badge_movies);
-            } else {
-                badgeText = category.toUpperCase();
-                if (badgeText.length() > 6) {
-                    badgeText = badgeText.substring(0, 6);
-                }
-                badgeColor = ContextCompat.getColor(context, R.color.type_badge_default); // Orange
+            badgeText = category.toUpperCase();
+            if (badgeText.length() > 6) {
+                badgeText = badgeText.substring(0, 6);
             }
+            badgeColor = ContextCompat.getColor(context, R.color.type_badge_default); // Orange
         }
         
         badge.setText(badgeText);

--- a/CineCraze/app/scr/main/java/com/cinecraze/free/stream/database/DatabaseUtils.java
+++ b/CineCraze/app/scr/main/java/com/cinecraze/free/stream/database/DatabaseUtils.java
@@ -50,6 +50,7 @@ public class DatabaseUtils {
         try {
             setPrivateField(entry, "title", entity.getTitle());
             setPrivateField(entry, "subCategory", entity.getSubCategory());
+            setPrivateField(entry, "mainCategory", entity.getMainCategory());
             setPrivateField(entry, "country", entity.getCountry());
             setPrivateField(entry, "description", entity.getDescription());
             setPrivateField(entry, "poster", entity.getPoster());

--- a/CineCraze/app/scr/main/java/com/cinecraze/free/stream/models/Entry.java
+++ b/CineCraze/app/scr/main/java/com/cinecraze/free/stream/models/Entry.java
@@ -20,6 +20,9 @@ public class Entry {
     @SerializedName("SubCategory")
     private String subCategory;
 
+    @SerializedName("MainCategory")
+    private String mainCategory;
+
     @SerializedName("Country")
     private String country;
 
@@ -56,6 +59,10 @@ public class Entry {
 
     public String getSubCategory() {
         return subCategory;
+    }
+
+    public String getMainCategory() {
+        return mainCategory;
     }
 
     public String getCountry() {


### PR DESCRIPTION
Implement dual badge system with correct data sources and specific colors across all adapters to fix badges showing default orange.

Previously, both genre and content type badges incorrectly used `subCategory` data, and the `mainCategory` (for content type) was not exposed. This PR exposes `mainCategory`, assigns it to the content type badge, uses `subCategory` for the genre badge, and applies the specified color logic for each, while also adding the missing badge functionality to `PaginatedMovieAdapter`.

---

[Open in Web](https://cursor.com/agents?id=bc-513ab417-a840-49d9-815e-65be7aa44aa9) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-513ab417-a840-49d9-815e-65be7aa44aa9) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)