### PR TITLE
Fix mpd links in github json data

### DIFF
--- a/CineCraze/app/src/main/java/com/cinecraze/free/stream/DetailsActivity.java
+++ b/CineCraze/app/src/main/java/com/cinecraze/free/stream/DetailsActivity.java
@@ -28,6 +28,7 @@ import com.google.gson.Gson;
 
 import java.util.ArrayList;
 import java.util.List;
+import com.google.android.exoplayer2.C;
 
 public class DetailsActivity extends AppCompatActivity {
 
@@ -314,15 +315,13 @@ public class DetailsActivity extends AppCompatActivity {
                     String kidB64 = android.util.Base64.encodeToString(hexStringToByteArray(kid), android.util.Base64.NO_WRAP);
                     String keyB64 = android.util.Base64.encodeToString(hexStringToByteArray(key), android.util.Base64.NO_WRAP);
                     String clearkeyJson = "{\"keys\":[{\"kty\":\"oct\",\"kid\":\"" + kidB64 + "\",\"k\":\"" + keyB64 + "\"}],\"type\":\"temporary\"}";
-                    MediaItem.DrmConfiguration drmConfig = new MediaItem.DrmConfiguration.Builder(androidx.media3.common.C.CLEARKEY_UUID)
-                        .setKeySetId(null)
+                    MediaItem.DrmConfiguration drmConfig = new MediaItem.DrmConfiguration.Builder(C.CLEARKEY_UUID)
                         .setLicenseUri("") // Not needed for clearkey
+                        .setKeySetId(null)
                         .setMultiSession(false)
                         .setForceDefaultLicenseUri(false)
                         .setLicenseRequestHeaders(null)
-                        .setSessionForClearTypes(false)
                         .setPlayClearContentWithoutKey(true)
-                        .setCustomData(clearkeyJson.getBytes())
                         .build();
                     mediaItem = new MediaItem.Builder()
                         .setUri(videoUrl)

--- a/CineCraze/app/src/main/java/com/cinecraze/free/stream/DetailsActivity.java
+++ b/CineCraze/app/src/main/java/com/cinecraze/free/stream/DetailsActivity.java
@@ -334,7 +334,8 @@ public class DetailsActivity extends AppCompatActivity {
                                 .build(drmCallback);
                         DashMediaSource.Factory dashFactory = new DashMediaSource.Factory(new DefaultHttpDataSource.Factory().setUserAgent(Util.getUserAgent(this, "CineCraze")));
                         dashFactory.setDrmSessionManagerProvider(mediaItem -> drmSessionManager);
-                        DashMediaSource dashMediaSource = dashFactory.createMediaSource(android.net.Uri.parse(videoUrl));
+                        MediaItem dashMediaItem = MediaItem.fromUri(videoUrl);
+                        DashMediaSource dashMediaSource = dashFactory.createMediaSource(dashMediaItem);
                         player.setMediaSource(dashMediaSource);
                         player.prepare();
                         player.play();

--- a/CineCraze/app/src/main/java/com/cinecraze/free/stream/DetailsActivity.java
+++ b/CineCraze/app/src/main/java/com/cinecraze/free/stream/DetailsActivity.java
@@ -38,7 +38,7 @@ import com.google.android.exoplayer2.drm.DrmSessionManager;
 import com.google.android.exoplayer2.drm.DrmInitData;
 import com.google.android.exoplayer2.drm.UnsupportedDrmException;
 import com.google.android.exoplayer2.source.dash.DashMediaSource;
-import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory;
+import com.google.android.exoplayer2.upstream.DefaultHttpDataSource;
 import com.google.android.exoplayer2.util.Util;
 import java.util.HashMap;
 import java.util.UUID;
@@ -329,7 +329,7 @@ public class DetailsActivity extends AppCompatActivity {
                         UUID drmSchemeUuid = C.CLEARKEY_UUID;
                         HashMap<String, String> keyRequestProperties = new HashMap<>();
                         keyRequestProperties.put("Content-Type", "application/json");
-                        MediaDrmCallback drmCallback = new HttpMediaDrmCallback("", new DefaultHttpDataSourceFactory(Util.getUserAgent(this, "CineCraze")), keyRequestProperties) {
+                        MediaDrmCallback drmCallback = new HttpMediaDrmCallback("", new DefaultHttpDataSource.Factory().setUserAgent(Util.getUserAgent(this, "CineCraze")), keyRequestProperties) {
                             @Override
                             public byte[] executeKeyRequest(UUID uuid, ExoMediaDrm.KeyRequest request) {
                                 return clearkeyJson.getBytes();
@@ -338,7 +338,7 @@ public class DetailsActivity extends AppCompatActivity {
                         DefaultDrmSessionManager drmSessionManager = new DefaultDrmSessionManager.Builder()
                                 .setUuidAndExoMediaDrmProvider(drmSchemeUuid, FrameworkMediaDrm.DEFAULT_PROVIDER)
                                 .build(drmCallback);
-                        DashMediaSource dashMediaSource = new DashMediaSource.Factory(new DefaultHttpDataSourceFactory(Util.getUserAgent(this, "CineCraze")))
+                        DashMediaSource dashMediaSource = new DashMediaSource.Factory(new DefaultHttpDataSource.Factory().setUserAgent(Util.getUserAgent(this, "CineCraze")))
                                 .setDrmSessionManager(drmSessionManager)
                                 .createMediaSource(android.net.Uri.parse(videoUrl));
                         player.setMediaSource(dashMediaSource);

--- a/CineCraze/app/src/main/java/com/cinecraze/free/stream/DetailsActivity.java
+++ b/CineCraze/app/src/main/java/com/cinecraze/free/stream/DetailsActivity.java
@@ -335,7 +335,9 @@ public class DetailsActivity extends AppCompatActivity {
                         // Build clearkey JSON
                         String kid = server.getDrmKid();
                         String key = server.getDrmKey();
-                        String clearkeyJson = "{\"keys\":[{\"kty\":\"oct\",\"kid\":\"" + kid + "\",\"k\":\"" + key + "\"}],\"type\":\"temporary\"}";
+                        String kidB64 = android.util.Base64.encodeToString(hexStringToByteArray(kid), android.util.Base64.NO_WRAP);
+                        String keyB64 = android.util.Base64.encodeToString(hexStringToByteArray(key), android.util.Base64.NO_WRAP);
+                        String clearkeyJson = "{\"keys\":[{\"kty\":\"oct\",\"kid\":\"" + kidB64 + "\",\"k\":\"" + keyB64 + "\"}],\"type\":\"temporary\"}";
                         // Setup DRM session manager
                         UUID drmSchemeUuid = C.CLEARKEY_UUID;
                         LocalMediaDrmCallback drmCallback = new LocalMediaDrmCallback(clearkeyJson.getBytes());

--- a/CineCraze/app/src/main/java/com/cinecraze/free/stream/DetailsActivity.java
+++ b/CineCraze/app/src/main/java/com/cinecraze/free/stream/DetailsActivity.java
@@ -43,6 +43,8 @@ import com.google.android.exoplayer2.util.Util;
 import java.util.HashMap;
 import java.util.UUID;
 import com.google.android.exoplayer2.drm.LocalMediaDrmCallback;
+import android.util.Log;
+import android.widget.Toast;
 
 public class DetailsActivity extends AppCompatActivity {
 
@@ -240,6 +242,14 @@ public class DetailsActivity extends AppCompatActivity {
         playerView.setPlayer(player);
         playerView.setControllerShowTimeoutMs(2000);
         playerView.setControllerHideOnTouch(true);
+
+        player.addListener(new com.google.android.exoplayer2.Player.Listener() {
+            @Override
+            public void onPlayerError(com.google.android.exoplayer2.PlaybackException error) {
+                Log.e("ExoPlayer", "Playback error: " + error.getMessage(), error);
+                Toast.makeText(DetailsActivity.this, "Playback error: " + error.getMessage(), Toast.LENGTH_LONG).show();
+            }
+        });
 
         ImageButton fullscreenButton = playerView.findViewById(R.id.exo_fullscreen_button);
         fullscreenButton.setOnClickListener(v -> {

--- a/CineCraze/app/src/main/java/com/cinecraze/free/stream/models/Server.java
+++ b/CineCraze/app/src/main/java/com/cinecraze/free/stream/models/Server.java
@@ -19,6 +19,9 @@ public class Server {
     @SerializedName("drm_key")
     private String drmKey;
 
+    @SerializedName("license")
+    private String license;
+
     public String getName() {
         return name;
     }
@@ -38,4 +41,6 @@ public class Server {
     public String getDrmKey() {
         return drmKey;
     }
+
+    public String getLicense() { return license; }
 }

--- a/CineCraze/app/src/main/java/com/cinecraze/free/stream/models/Server.java
+++ b/CineCraze/app/src/main/java/com/cinecraze/free/stream/models/Server.java
@@ -10,11 +10,32 @@ public class Server {
     @SerializedName("url")
     private String url;
 
+    @SerializedName("is_drm_protected")
+    private boolean isDrmProtected;
+
+    @SerializedName("drm_kid")
+    private String drmKid;
+
+    @SerializedName("drm_key")
+    private String drmKey;
+
     public String getName() {
         return name;
     }
 
     public String getUrl() {
         return url;
+    }
+
+    public boolean isDrmProtected() {
+        return isDrmProtected;
+    }
+
+    public String getDrmKid() {
+        return drmKid;
+    }
+
+    public String getDrmKey() {
+        return drmKey;
     }
 }

--- a/playlist.json
+++ b/playlist.json
@@ -1,0 +1,4114 @@
+{
+  "Categories": [
+    {
+      "MainCategory": "Live TV",
+      "SubCategories": [
+        "Entertainment"
+      ],
+      "Entries": [
+        {
+          "Title": "AZ2",
+          "SubCategory": "Entertainment",
+          "Country": "🇵🇭 Philippines",
+          "Description": "AZ2",
+          "Poster": "https://i.imgur.com/1zsdloF.png",
+          "Thumbnail": "https://i.imgur.com/1zsdloF.png",
+          "Rating": 0,
+          "Servers": [
+            {
+              "name": "720p",
+              "url": "https://qp-pldt-live-grp-02-prod.akamaized.net/out/u/tv5_5.m3u8"
+            },
+            {
+              "name": "480p",
+              "url": "https://qp-pldt-live-grp-02-prod.akamaized.net/out/u/tv5_4.m3u8"
+            },
+            {
+              "name": "360p",
+              "url": "https://qp-pldt-live-grp-02-prod.akamaized.net/out/u/tv5_3.m3u8"
+            },
+            {
+              "name": "240p",
+              "url": "https://qp-pldt-live-grp-02-prod.akamaized.net/out/u/tv5_2.m3u8"
+            },
+            {
+              "name": "144p",
+              "url": "https://qp-pldt-live-grp-02-prod.akamaized.net/out/u/tv5_1.m3u8"
+            }
+          ]
+        },
+        {
+          "Title": "HBO Family Asia",
+          "SubCategory": "Movies",
+          "Country": "🌐 Asia",
+          "Description": "HBO Family Asia is a pay television network that features family-friendly movies.",
+          "Poster": "https://i.imgur.com/5krGyOX.png",
+          "Thumbnail": "https://i.imgur.com/5krGyOX.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://qp-pldt-live-grp-03-prod.akamaized.net/out/u/cg_hbofam.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "One Sport+",
+          "SubCategory": "Sports",
+          "Country": "🇵🇭 Philippines",
+          "Description": "One Sports+ is a Filipino pay television channel.",
+          "Poster": "https://i.imgur.com/cb9Hp32.png",
+          "Thumbnail": "https://i.imgur.com/cb9Hp32.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://qp-pldt-live-grp-03-prod.akamaized.net/out/u/cg_onesportsplus_hd1.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "PBA Rush",
+          "SubCategory": "Sports",
+          "Country": "🇵🇭 Philippines",
+          "Description": "PBA Rush is a 24/7 channel which has been dedicated to broadcast the PBA Games.",
+          "Poster": "https://i.imgur.com/FmvPl3U.png",
+          "Thumbnail": "https://i.imgur.com/FmvPl3U.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://qp-pldt-live-grp-01-prod.akamaized.net/out/u/cg_pbarush_hd1.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "NBA TV Philippines",
+          "SubCategory": "Sports",
+          "Country": "🇵🇭 Philippines",
+          "Description": "NBA TV Philippines is a Filipino pay television channel that is dedicated to basketball.",
+          "Poster": "https://i.imgur.com/zC6ul0L.png",
+          "Thumbnail": "https://i.imgur.com/zC6ul0L.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "SD",
+              "url": "https://qp-pldt-live-grp-02-prod.akamaized.net/out/u/nba_sdi.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "Premier Sports",
+          "SubCategory": "Sports",
+          "Country": "🌐 International",
+          "Description": "Premier Sports is a British pay television sports channel.",
+          "Poster": "https://i.imgur.com/iTZsuwE.png",
+          "Thumbnail": "https://i.imgur.com/iTZsuwE.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://qp-pldt-live-grp-13-prod.akamaized.net/out/u/dr_premiertennishd.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "SPOTV",
+          "SubCategory": "Sports",
+          "Country": "🌐 Asia",
+          "Description": "SPOTV is a South Korean pay television network that features sports programming.",
+          "Poster": "https://i.imgur.com/odMlNlu.png",
+          "Thumbnail": "https://i.imgur.com/odMlNlu.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://qp-pldt-live-grp-11-prod.akamaized.net/out/u/dr_spotvhd.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "Football TV",
+          "SubCategory": "Sports",
+          "Country": "🌐 International",
+          "Description": "A TV channel dedicated to football.",
+          "Poster": "https://images.deepai.org/art-image/0f3456df03504154b9c4c9e2bbbe0bf6/football-logo-6e9e48.jpg",
+          "Thumbnail": "https://images.deepai.org/art-image/0f3456df03504154b9c4c9e2bbbe0bf6/football-logo-6e9e48.jpg",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://live20.bozztv.com/trn03/gin-ssfootball/index.m3u8"
+            }
+          ]
+        },
+        {
+          "Title": "Cartoonito Asia",
+          "SubCategory": "Animation",
+          "Country": "🌐 Asia",
+          "Description": "Cartoonito is a pay television channel that features programming for preschoolers.",
+          "Poster": "https://i.imgur.com/oTAZpMX.png",
+          "Thumbnail": "https://i.imgur.com/oTAZpMX.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://streaming.indihometv.com/atm/DASH/boomerang/manifest.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "Cartoon Network Asia",
+          "SubCategory": "Animation",
+          "Country": "🌐 Asia",
+          "Description": "Cartoon Network is a pay television channel that features animated programming.",
+          "Poster": "https://i.imgur.com/NA0v02i.png",
+          "Thumbnail": "https://i.imgur.com/NA0v02i.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://qp-pldt-live-grp-12-prod.akamaized.net/out/u/dr_cartoonnetworkhd.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "Animax Asia",
+          "SubCategory": "Animation",
+          "Country": "🌐 Asia",
+          "Description": "Animax is a pay television channel that features Japanese anime.",
+          "Poster": "https://i.imgur.com/60ltJNZ.png",
+          "Thumbnail": "https://i.imgur.com/60ltJNZ.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "SD",
+              "url": "https://qp-pldt-live-grp-07-prod.akamaized.net/out/u/cg_animax_sd_new.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "Mr. Bean",
+          "SubCategory": "Comedy",
+          "Country": "🇬🇧 United Kingdom",
+          "Description": "Mr. Bean is a British sitcom created by Rowan Atkinson and Richard Curtis.",
+          "Poster": "https://images.deepai.org/art-image/9adc6f1f1c524b8ea3b09b31284dffef/mr-bean-cartoon-with-text-logo-355a93.jpg",
+          "Thumbnail": "https://images.deepai.org/art-image/9adc6f1f1c524b8ea3b09b31284dffef/mr-bean-cartoon-with-text-logo-355a93.jpg",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://amg00627-amg00627c30-rakuten-es-3990.playouts.now.amagi.tv/playlist/amg00627-banijayfast-mrbeanescc-rakutenes/playlist.m3u8"
+            }
+          ]
+        },
+        {
+          "Title": "Cartoon Classic",
+          "SubCategory": "Animation",
+          "Country": "🌐 International",
+          "Description": "A channel dedicated to classic cartoons.",
+          "Poster": "https://images.deepai.org/art-image/bb6cec15a5cb4b8589835904396b3eff/cartoon-classic-logo-8472ab.jpg",
+          "Thumbnail": "https://images.deepai.org/art-image/bb6cec15a5cb4b8589835904396b3eff/cartoon-classic-logo-8472ab.jpg",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://streams2.sofast.tv/v1/master/611d79b11b77e2f571934fd80ca1413453772ac7/d5543c06-5122-49a7-9662-32187f48aa2c/manifest.m3u8"
+            }
+          ]
+        },
+        {
+          "Title": "Moonbug Kids",
+          "SubCategory": "Animation",
+          "Country": "🌐 International",
+          "Description": "Moonbug Kids is a channel for kids.",
+          "Poster": "https://i.imgur.com/vUpIbVN.png",
+          "Thumbnail": "https://i.imgur.com/vUpIbVN.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "SD",
+              "url": "https://qp-pldt-live-grp-06-prod.akamaized.net/out/u/cg_moonbug_kids_sd.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "Asian Food Network",
+          "SubCategory": "Lifestyle",
+          "Country": "🌐 Asia",
+          "Description": "Asian Food Network is a pay television channel that features food and dining programming.",
+          "Poster": "https://i.imgur.com/0CRk7Nf.png",
+          "Thumbnail": "https://i.imgur.com/0CRk7Nf.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "SD",
+              "url": "https://qp-pldt-live-grp-07-prod.akamaized.net/out/u/asianfoodnetwork_sd.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "Animal Planet Asia",
+          "SubCategory": "Documentary",
+          "Country": "🌐 Asia",
+          "Description": "Animal Planet is a pay television channel that features programming about animals.",
+          "Poster": "https://i.imgur.com/3UMiEgD.png",
+          "Thumbnail": "https://i.imgur.com/3UMiEgD.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "SD",
+              "url": "https://qp-pldt-live-grp-02-prod.akamaized.net/out/u/cg_animal_planet_sd.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "History Asia",
+          "SubCategory": "Documentary",
+          "Country": "🌐 Asia",
+          "Description": "History is a pay television channel that features historical programming.",
+          "Poster": "https://i.imgur.com/9zVyTXV.png",
+          "Thumbnail": "https://i.imgur.com/9zVyTXV.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://qp-pldt-live-grp-11-prod.akamaized.net/out/u/dr_historyhd.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "Discovery Asia",
+          "SubCategory": "Documentary",
+          "Country": "🌐 Asia",
+          "Description": "Discovery Channel is a pay television channel that features documentary programming.",
+          "Poster": "https://i.imgur.com/SbiPKql.png",
+          "Thumbnail": "https://i.imgur.com/SbiPKql.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://qp-pldt-live-grp-12-prod.akamaized.net/out/u/dr_discoveryasia.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "Knowledge Channel",
+          "SubCategory": "Educational",
+          "Country": "🇵🇭 Philippines",
+          "Description": "Knowledge Channel is a Filipino pay television channel that features educational programming.",
+          "Poster": "https://i.imgur.com/tLUSj5p.png",
+          "Thumbnail": "https://i.imgur.com/tLUSj5p.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://abslive.akamaized.net/dash/live/2028189/kc/manifest.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "Trvl Channel",
+          "SubCategory": "Lifestyle",
+          "Country": "🌐 International",
+          "Description": "Travel Channel is a pay television channel that features travel programming.",
+          "Poster": "https://i.imgur.com/GfqMnG6.png",
+          "Thumbnail": "https://i.imgur.com/GfqMnG6.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "SD",
+              "url": "https://qp-pldt-live-grp-08-prod.akamaized.net/out/u/travel_channel_sd.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "HITS Now",
+          "SubCategory": "Entertainment",
+          "Country": "🌐 Asia",
+          "Description": "HITS Now is a Southeast Asian pay television channel that features a variety of programs from the U.S.",
+          "Poster": "https://i.imgur.com/FV3NTrr.png",
+          "Thumbnail": "https://i.imgur.com/FV3NTrr.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://qp-pldt-live-grp-09-prod.akamaized.net/out/u/cg_hitsnow.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "Food Network Asia",
+          "SubCategory": "Lifestyle",
+          "Country": "🌐 Asia",
+          "Description": "Food Network is a pay television channel that features food and dining programming.",
+          "Poster": "https://i.imgur.com/Gwd2TNB.png",
+          "Thumbnail": "https://i.imgur.com/Gwd2TNB.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://qp-pldt-live-grp-09-prod.akamaized.net/out/u/cg_foodnetwork_hd1.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "TLC Asia",
+          "SubCategory": "Lifestyle",
+          "Country": "🌐 Asia",
+          "Description": "TLC is a pay television channel that features lifestyle programming.",
+          "Poster": "https://i.imgur.com/xvpDd5F.png",
+          "Thumbnail": "https://i.imgur.com/xvpDd5F.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "SD",
+              "url": "https://qp-pldt-live-grp-08-prod.akamaized.net/out/u/tlc_sd.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "AXN Asia",
+          "SubCategory": "Entertainment",
+          "Country": "🌐 Asia",
+          "Description": "AXN is a pay television channel that features action-packed entertainment.",
+          "Poster": "https://i.imgur.com/Y9vnT7K.png",
+          "Thumbnail": "https://i.imgur.com/Y9vnT7K.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "SD",
+              "url": "https://qp-pldt-live-grp-06-prod.akamaized.net/out/u/cg_axn_sd.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "Channel News Asia",
+          "SubCategory": "News",
+          "Country": "🇸🇬 Singapore",
+          "Description": "CNA is a Singaporean pay television news channel.",
+          "Poster": "https://i.imgur.com/CbsDpEd.png",
+          "Thumbnail": "https://i.imgur.com/CbsDpEd.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://qp-pldt-live-grp-13-prod.akamaized.net/out/u/dr_channelnewsasia.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "BBC News SD",
+          "SubCategory": "News",
+          "Country": "🇬🇧 United Kingdom",
+          "Description": "BBC News is a British pay television news channel.",
+          "Poster": "https://i.imgur.com/gJ8Rxr4.png",
+          "Thumbnail": "https://i.imgur.com/gJ8Rxr4.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "SD",
+              "url": "https://qp-pldt-live-grp-04-prod.akamaized.net/out/u/bbcworld_news_sd.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "Uaap Varsity Channel",
+          "SubCategory": "Sports",
+          "Country": "🇵🇭 Philippines",
+          "Description": "The UAAP Varsity Channel is a Filipino pay television channel.",
+          "Poster": "https://i.imgur.com/4YPSDQg.png",
+          "Thumbnail": "https://i.imgur.com/4YPSDQg.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "SD",
+              "url": "https://qp-pldt-live-grp-04-prod.akamaized.net/out/u/cg_uaap_cplay_sd.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "CCTN 47",
+          "SubCategory": "Entertainment",
+          "Country": "🇵🇭 Philippines",
+          "Description": "CCTN stands for Cebu Catholic Television Network.",
+          "Poster": "https://i.imgur.com/nV9QXh5.png",
+          "Thumbnail": "https://i.imgur.com/nV9QXh5.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "http://122.55.252.134:8443/live/bba5b536faeacb9b56a3239f1ee8e3b3/1.m3u8"
+            }
+          ]
+        },
+        {
+          "Title": "CLTV 36",
+          "SubCategory": "Entertainment",
+          "Country": "🇵🇭 Philippines",
+          "Description": "CLTV36 is a regional television station in Central Luzon.",
+          "Poster": "https://i.imgur.com/bJe76EA.png",
+          "Thumbnail": "https://i.imgur.com/bJe76EA.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://live.cltv36.tv:5443/LiveApp/streams/cltvlive.m3u8"
+            }
+          ]
+        },
+        {
+          "Title": "INC TV",
+          "SubCategory": "Religious",
+          "Country": "🇵🇭 Philippines",
+          "Description": "INC TV is the official television station of the Iglesia ni Cristo.",
+          "Poster": "https://i.imgur.com/O4mv3Bu.png",
+          "Thumbnail": "https://i.imgur.com/O4mv3Bu.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://199211.global.ssl.fastly.net/643cc12aa824db4374021c8c/live_95f6ac80dd6511ed9d08b12be56ae55e/index.m3u8"
+            }
+          ]
+        },
+        {
+          "Title": "Mindanow Network TV",
+          "SubCategory": "Entertainment",
+          "Country": "🇵🇭 Philippines",
+          "Description": "Mindanow TV is a regional television station in Mindanao.",
+          "Poster": "https://i.imgur.com/xBlYirh.jpeg",
+          "Thumbnail": "https://i.imgur.com/xBlYirh.jpeg",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://streams1.comclark.com/overlay/mindanow/playlist.m3u8"
+            }
+          ]
+        },
+        {
+          "Title": "ANC HD",
+          "SubCategory": "News",
+          "Country": "🇵🇭 Philippines",
+          "Description": "The ABS-CBN News Channel, commonly known as ANC, is a 24/7 Philippine pay television news channel.",
+          "Poster": "https://i.imgur.com/6l5x8Tx.png",
+          "Thumbnail": "https://i.imgur.com/6l5x8Tx.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://d3cjss68xc4sia.cloudfront.net/out/v1/89ea8db23cb24a91bfa5d0795f8d759e/index.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "Fox5",
+          "SubCategory": "News",
+          "Country": "🇺🇸 United States",
+          "Description": "Fox 5 is a Fox owned-and-operated television station licensed to New York City.",
+          "Poster": "https://th.bing.com/th/id/R.da0efd0a8ae25cc3ed689c0b82f00948?rik=93YX0cls8nM62A&riu=http%3a%2f%2fvebaresourcecenter.com%2fwp-content%2fuploads%2f2021%2f02%2fFox-5.png&ehk=3cscegNe6kvhaAcpuOcaGPc9qXfPNTGNPpzce1K%2bGoI%3d&risl=&pid=ImgRaw&r=0&sres=1&sresct=1",
+          "Thumbnail": "https://th.bing.com/th/id/R.da0efd0a8ae25cc3ed689c0b82f00948?rik=93YX0cls8nM62A&riu=http%3a%2f%2fvebaresourcecenter.com%2fwp-content%2fuploads%2f2021%2f02%2fFox-5.png&ehk=3cscegNe6kvhaAcpuOcaGPc9qXfPNTGNPpzce1K%2bGoI%3d&risl=&pid=ImgRaw&r=0&sres=1&sresct=1",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://live20.bozztv.com/dvrfl05/gin-fox5/index.m3u8"
+            }
+          ]
+        },
+        {
+          "Title": "PHTV",
+          "SubCategory": "Entertainment",
+          "Country": "🇵🇭 Philippines",
+          "Description": "PHTV is a Filipino television station.",
+          "Poster": "https://yt3.ggpht.com/a/AATXAJyBhvv8T9RzinRRiGuWjkg-S4Qlse33y3pWiA=s900-c-k-c0xffffffff-no-rj-mo",
+          "Thumbnail": "https://yt3.ggpht.com/a/AATXAJyBhvv8T9RzinRRiGuWjkg-S4Qlse33y3pWiA=s900-c-k-c0xffffffff-no-rj-mo",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://live20.bozztv.com/giatvplayout7/giatv-209998/tracks-v1a1/mono.m3u8"
+            }
+          ]
+        },
+        {
+          "Title": "GMA PinoyTV",
+          "SubCategory": "Entertainment",
+          "Country": "🇵🇭 PH",
+          "Description": "",
+          "Poster": "https://i.imgur.com/Jinf00v.png",
+          "Thumbnail": "https://i.imgur.com/Jinf00v.png",
+          "Rating": 8,
+          "Servers": [
+            {
+              "name": "Live",
+              "url": "https://amg01006-abs-cbn-abscbn-gma-x7-dash-abscbnono-dzsx9.amagi.tv/index.mpd"
+            }
+          ]
+        },
+        {
+  "Title": "TV5",
+  "SubCategory": "Entertainment",
+  "Country": "🇵🇭 PH",
+  "Description": "TV5 is a major Filipino commercial television network based in Mandaluyong City.",
+  "Poster": "https://i.imgur.com/Ufp278A.png",
+  "Thumbnail": "https://i.imgur.com/Ufp278A.png",
+  "Rating": 0,
+  "Duration": "",
+  "Year": 0,
+  "Servers": [
+    {
+      "name": "HD",
+      "url": "https://qp-pldt-live-grp-02-prod.akamaized.net/out/u/tv5_hd.mpd",
+      "is_drm_protected": true,
+      "drm_kid": "2615129ef2c846a9bbd43a641c7303ef",
+      "drm_key": "07c7f996b1734ea288641a68e1cfdc4d"
+    }
+  ]
+},
+        {
+          "Title": "Pinoy Box Office",
+          "SubCategory": "Movies",
+          "Country": "🇵🇭 PH",
+          "Description": "Pinoy Box Office (PBO) is a 24-hour Filipino cable television network.",
+          "Poster": "https://i.imgur.com/u385Aaa.png",
+          "Thumbnail": "https://i.imgur.com/u385Aaa.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "SD",
+              "url": "https://qp-pldt-live-grp-04-prod.akamaized.net/out/u/pbo_sd.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "Cinema One",
+          "SubCategory": "Movies",
+          "Country": "🇵🇭 PH",
+          "Description": "Cinema One is a Filipino cable television network based in Quezon City.",
+          "Poster": "https://i.imgur.com/ePXmpqr.png",
+          "Thumbnail": "https://i.imgur.com/ePXmpqr.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://live-faws.akamaized.net/out/v1/9c02b2581c6a4a22a089ecbd369933f5/index.m3u8"
+            }
+          ]
+        },
+        {
+          "Title": "Cine Mo!",
+          "SubCategory": "Movies",
+          "Country": "🇵🇭 PH",
+          "Description": "Cine Mo! is a Filipino pay television channel owned by ABS-CBN.",
+          "Poster": "https://i.imgur.com/KUwrSOH.png",
+          "Thumbnail": "https://i.imgur.com/KUwrSOH.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://d1bail49udbz1k.cloudfront.net/out/v1/78e282e04f0944f3ad0aa1db7a1be645/index.m3u8"
+            }
+          ]
+        },
+        {
+          "Title": "VIVA Cinema",
+          "SubCategory": "Movies",
+          "Country": "🇵🇭 PH",
+          "Description": "Viva Cinema is a Filipino cable television network that broadcasts Filipino-dubbed local and foreign movies.",
+          "Poster": "https://i.imgur.com/GsejzSt.png",
+          "Thumbnail": "https://i.imgur.com/GsejzSt.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "SD",
+              "url": "https://qp-pldt-live-grp-06-prod.akamaized.net/out/u/viva_sd.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "KingMovie",
+          "SubCategory": "Movies",
+          "Country": "🌐International",
+          "Description": "KingMovie is a streaming service for movies.",
+          "Poster": "https://yt3.ggpht.com/a/AATXAJwG4flJwodLuUwXoT9W0t5HIvpB_-JZyRSCCw=s900-c-k-c0xffffffff-no-rj-mo",
+          "Thumbnail": "https://yt3.ggpht.com/a/AATXAJwG4flJwodLuUwXoT9W0t5HIvpB_-JZyRSCCw=s900-c-k-c0xffffffff-no-rj-mo",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://live20.bozztv.com/giatvplayout7/giatv-210044/tracks-v1a1/mono.m3u8"
+            }
+          ]
+        },
+        {
+          "Title": "Celestial Movies Pinoy",
+          "SubCategory": "Movies",
+          "Country": "🇵🇭 PH",
+          "Description": "Celestial Movies Pinoy is a Filipino-dubbed movie channel.",
+          "Poster": "https://i.imgur.com/EkmCzO1.png",
+          "Thumbnail": "https://i.imgur.com/EkmCzO1.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "SD",
+              "url": "https://qp-pldt-live-grp-01-prod.akamaized.net//out/u/celmovie_pinoy_sd.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "Tagalized Movie Channel (TMC)",
+          "SubCategory": "Movies",
+          "Country": "🇵🇭 PH",
+          "Description": "The first and only 24/7 Tagalized movie channel in the Philippines.",
+          "Poster": "https://i.imgur.com/nVs49ps.png",
+          "Thumbnail": "https://i.imgur.com/nVs49ps.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://qp-pldt-live-grp-07-prod.akamaized.net/out/u/cg_tagalogmovie.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "Cinemax Asia",
+          "SubCategory": "Movies",
+          "Country": "Asia",
+          "Description": "Cinemax Asia is a pay television network that features action, science-fiction, thriller and horror movies.",
+          "Poster": "https://i.imgur.com/NLxg6Va.png",
+          "Thumbnail": "https://i.imgur.com/NLxg6Va.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://qp-pldt-live-grp-01-prod.akamaized.net/out/u/cg_cinemax.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "KIX",
+          "SubCategory": "Action",
+          "Country": "Asia",
+          "Description": "KIX is a Southeast Asian pay television channel owned by Celestial Tiger Entertainment.",
+          "Poster": "https://i.imgur.com/QSfKYPJ.png",
+          "Thumbnail": "https://i.imgur.com/QSfKYPJ.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://streaming.indihometv.com/atm/DASH/kix/manifest.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "Thrill",
+          "SubCategory": "Horror",
+          "Country": "Asia",
+          "Description": "Thrill is a Southeast Asian pay television channel owned by Celestial Tiger Entertainment.",
+          "Poster": "https://i.imgur.com/PRp3gAG.png",
+          "Thumbnail": "https://i.imgur.com/PRp3gAG.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "SD",
+              "url": "https://qp-pldt-live-grp-06-prod.akamaized.net/out/u/cg_thrill_sd.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "HBO Asia",
+          "SubCategory": "Movies",
+          "Country": "Asia",
+          "Description": "HBO Asia is a pay television network that features Hollywood blockbusters and original productions.",
+          "Poster": "https://i.imgur.com/ucIzYgj.png",
+          "Thumbnail": "https://i.imgur.com/ucIzYgj.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://qp-pldt-live-grp-03-prod.akamaized.net/out/u/cg_hbohd.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "ROCK Action",
+          "SubCategory": "Action",
+          "Country": "Asia",
+          "Description": "ROCK Action is a Southeast Asian pay television channel that features action-packed movies and series.",
+          "Poster": "https://i.imgur.com/yJhZN08.png",
+          "Thumbnail": "https://i.imgur.com/yJhZN08.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://qp-pldt-live-grp-13-prod.akamaized.net/out/u/dr_rockextreme.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "HITS Movies",
+          "SubCategory": "Movies",
+          "Country": "Asia",
+          "Description": "HITS Movies is a Southeast Asian pay television channel that features blockbuster hits from the 1960s to the 1990s.",
+          "Poster": "https://i.imgur.com/2a0CHbg.png",
+          "Thumbnail": "https://i.imgur.com/2a0CHbg.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://qp-pldt-live-grp-12-prod.akamaized.net/out/u/dr_hitsmovies.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "DreamWorks (Tagalized)",
+          "SubCategory": "Animation",
+          "Country": "🇵🇭 PH",
+          "Description": "DreamWorks Channel is a pay television network that features animated series and movies from DreamWorks Animation.",
+          "Poster": "https://i.imgur.com/yllKClE.png",
+          "Thumbnail": "https://i.imgur.com/yllKClE.png",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 0,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://qp-pldt-live-grp-07-prod.akamaized.net/out/u/cg_dreamworktag.mpd"
+            }
+          ]
+        },
+        {
+          "Title": "Kapamilya Channel",
+          "SubCategory": "General",
+          "Country": "🇵🇭 PH",
+          "Description": "",
+          "Poster": "https://i.imgur.com/Dcys2TG.png",
+          "Thumbnail": "https://i.imgur.com/Dcys2TG.png",
+          "Rating": 8,
+          "Servers": [
+            {
+              "name": "Live",
+              "url": "https://live-faws.akamaized.net/out/v1/df7b60b4411f4270ab431913de807bf4/index.m3u8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "MainCategory": "Movies",
+      "SubCategories": [
+        "Action"
+      ],
+      "Entries": [
+        {
+          "Title": "Triple Threat",
+          "SubCategory": "",
+          "Country": "",
+          "Description": "",
+          "Poster": "",
+          "Thumbnail": "",
+          "Rating": 0,
+          "Duration": "",
+          "Year": 2020,
+          "Servers": [
+            {
+              "name": "1080p",
+              "url": "https://vidsrc.me/embed/movie?imdb=tt9233514"
+            }
+          ]
+        },
+        {
+          "Title": "Hanggat May Hininga",
+          "SubCategory": "Action",
+          "Country": "",
+          "Description": "A pinoy old movie",
+          "Poster": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTQ8Vva_JHrKT3ZxYN8gwT9adxW8ROgvv2cf7GQo4X6zNBTc8jdgnlUKBw&s=10",
+          "Thumbnail": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTQ8Vva_JHrKT3ZxYN8gwT9adxW8ROgvv2cf7GQo4X6zNBTc8jdgnlUKBw&s=10",
+          "Rating": 6,
+          "Duration": "2:00:00",
+          "Year": 1997,
+          "Servers": [
+            {
+              "name": "4k",
+              "url": "https://youtu.be/vvCzT-8PIho?si=sX0OLUOJg8l2biXx"
+            },
+            {
+              "name": "1080p",
+              "url": "nd"
+            },
+            {
+              "name": "720p",
+              "url": "nfnf"
+            },
+            {
+              "name": "480p",
+              "url": "nfnf"
+            },
+            {
+              "name": "360p",
+              "url": "fn"
+            },
+            {
+              "name": "240p",
+              "url": "nfjf"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "MainCategory": "TV Series",
+      "SubCategories": [
+        "Anime",
+        "Action,Anime",
+        "General"
+      ],
+      "Entries": [
+        {
+          "Title": "Moonshine",
+          "SubCategory": "Historical, Romance, Drama",
+          "Country": "South Korea 🇰🇷",
+          "Description": "During the prohibition era in Joseon, a strict inspector pursues a noblewoman who secretly brews alcohol to save her family from poverty, leading to unexpected romance and conflicts.",
+          "Poster": "https://image.tmdb.org/t/p/original/dJAlUCdFWAso5cowfv3vhI2QtZY.jpg",
+          "Thumbnail": "https://image.tmdb.org/t/p/original/dJAlUCdFWAso5cowfv3vhI2QtZY.jpg",
+          "Rating": 8,
+          "Year": 2021,
+          "Seasons": [
+            {
+              "Season": 1,
+              "SeasonPoster": "https://image.tmdb.org/t/p/original/dJAlUCdFWAso5cowfv3vhI2QtZY.jpg",
+              "Episodes": [
+                {
+                  "Episode": 1,
+                  "Title": "The Alcohol Inspector",
+                  "Duration": "60 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "SD",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800708.us.archive.org/32/items/moonshine-south-korean-tv-series/Moonshine%201.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 2,
+                  "Title": "The Secret Brewery",
+                  "Duration": "60 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "SD",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800708.us.archive.org/32/items/moonshine-south-korean-tv-series/Moonshine%202.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 3,
+                  "Title": "Unexpected Encounter",
+                  "Duration": "60 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "SD",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800708.us.archive.org/32/items/moonshine-south-korean-tv-series/Moonshine%203.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 4,
+                  "Title": "The Investigation Begins",
+                  "Duration": "60 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "SD",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800708.us.archive.org/32/items/moonshine-south-korean-tv-series/Moonshine%204.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 5,
+                  "Title": "Hidden Identities",
+                  "Duration": "60 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "SD",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800708.us.archive.org/32/items/moonshine-south-korean-tv-series/Moonshine%205.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 6,
+                  "Title": "Dangerous Attraction",
+                  "Duration": "60 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "SD",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800708.us.archive.org/32/items/moonshine-south-korean-tv-series/Moonshine%206.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 7,
+                  "Title": "Family Secrets",
+                  "Duration": "60 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "SD",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800708.us.archive.org/32/items/moonshine-south-korean-tv-series/Moonshine%207.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 8,
+                  "Title": "The Royal Decree",
+                  "Duration": "60 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "SD",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800708.us.archive.org/32/items/moonshine-south-korean-tv-series/Moonshine%208.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 9,
+                  "Title": "Forbidden Tastes",
+                  "Duration": "60 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "SD",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800708.us.archive.org/32/items/moonshine-south-korean-tv-series/Moonshine%209.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 10,
+                  "Title": "Crossroads",
+                  "Duration": "60 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "SD",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800708.us.archive.org/32/items/moonshine-south-korean-tv-series/Moonshine%2010.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 11,
+                  "Title": "Exposed Truths",
+                  "Duration": "60 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "SD",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800708.us.archive.org/32/items/moonshine-south-korean-tv-series/Moonshine%2011.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 12,
+                  "Title": "Political Schemes",
+                  "Duration": "60 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "SD",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800708.us.archive.org/32/items/moonshine-south-korean-tv-series/Moonshine%2012.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 13,
+                  "Title": "Sacrifices",
+                  "Duration": "60 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "SD",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800708.us.archive.org/32/items/moonshine-south-korean-tv-series/Moonshine%2013.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 14,
+                  "Title": "Reckoning",
+                  "Duration": "60 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "SD",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800708.us.archive.org/32/items/moonshine-south-korean-tv-series/Moonshine%2014.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 15,
+                  "Title": "Final Preparations",
+                  "Duration": "60 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "SD",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800708.us.archive.org/32/items/moonshine-south-korean-tv-series/Moonshine%2015.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 16,
+                  "Title": "A New Dawn",
+                  "Duration": "60 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "SD",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800708.us.archive.org/32/items/moonshine-south-korean-tv-series/Moonshine%2016.mp4"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Title": "Inspector Gadget",
+          "SubCategory": "Animation, Comedy, Family",
+          "Country": "🇨🇦🇺🇸 Canada/USA",
+          "Description": "Inspector Gadget is a bumbling yet lovable cyborg policeman who is equipped with an endless array of gadgets. Along with his clever niece Penny and their dog Brain, Gadget battles the evil Dr. Claw and the MAD organization.",
+          "Poster": "https://static.wikia.nocookie.net/inspectorgadget/images/3/3d/Go_Go_Gadget_Collection.jpg",
+          "Thumbnail": "",
+          "Rating": "TV-Y7",
+          "Year": 1983,
+          "Seasons": [
+            {
+              "Season": 1,
+              "SeasonPoster": "https://static.wikia.nocookie.net/inspectorgadget/images/3/3d/Go_Go_Gadget_Collection.jpg",
+              "Episodes": [
+                {
+                  "Episode": 1,
+                  "Title": "Winter Olympics",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E01%20Winter%20Olympics.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E01%20Winter%20Olympics.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 2,
+                  "Title": "Monster Lake",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E02%20Monster%20Lake.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E02%20Monster%20Lake.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 3,
+                  "Title": "Down on the Farm",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E03%20Down%20on%20the%20Farm.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E03%20Down%20on%20the%20Farm.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 4,
+                  "Title": "Gadget at the Circus",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E04%20Gadget%20at%20the%20Circus.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E04%20Gadget%20at%20the%20Circus.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 5,
+                  "Title": "The Amazon",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E05%20The%20Amazon.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E05%20The%20Amazon.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 6,
+                  "Title": "Health Spa",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E06%20Health%20Spa.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E06%20Health%20Spa.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 7,
+                  "Title": "The Boat",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E07%20The%20Boat.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E07%20The%20Boat.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 8,
+                  "Title": "Haunted Castle",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E08%20Haunted%20Castle.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E08%20Haunted%20Castle.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 9,
+                  "Title": "Race to the Finish",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E09%20Race%20to%20the%20Finish.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E09%20Race%20to%20the%20Finish.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 10,
+                  "Title": "The Ruby",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E10%20The%20Ruby.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E10%20The%20Ruby.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 11,
+                  "Title": "A Star is Lost",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E11%20A%20Star%20is%20Lost.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E11%20A%20Star%20is%20Lost.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 12,
+                  "Title": "All That Glitters",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E12%20All%20That%20Glitters.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E12%20All%20That%20Glitters.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 13,
+                  "Title": "Movie Set",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E13%20Movie%20Set.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E13%20Movie%20Set.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 14,
+                  "Title": "Amusement Park",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E14%20Amusement%20Park.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E14%20Amusement%20Park.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 15,
+                  "Title": "Art Heist",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E15%20Art%20Heist.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E15%20Art%20Heist.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 16,
+                  "Title": "Volcano Island (Gadget Goes Hawaiian)",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E16%20Volcano%20Island%20%28Gadget%20Goes%20Hawaiian%29.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E16%20Volcano%20Island%20%28Gadget%20Goes%20Hawaiian%29.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 17,
+                  "Title": "The Invasion",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E17%20The%20Invasion.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E17%20The%20Invasion.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 18,
+                  "Title": "The Infiltration",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E18%20The%20Infiltration.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E18%20The%20Infiltration.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 19,
+                  "Title": "The Curse of the Pharoah (Poot-Ta-Foot's Curse)",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E19%20The%20Curse%20of%20the%20Pharoah%20%28Poot-Ta-Foot%27s%20Curse%29.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E19%20The%20Curse%20of%20the%20Pharoah%20%28Poot-Ta-Foot%27s%20Curse%29.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 20,
+                  "Title": "M.A.D. Trap",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E20%20M.A.D.%20Trap.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E20%20M.A.D.%20Trap.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 21,
+                  "Title": "Basic Training",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E21%20Basic%20Training.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E21%20Basic%20Training.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 22,
+                  "Title": "Sleeping Gas",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E22%20Sleeping%20Gas.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E22%20Sleeping%20Gas.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 23,
+                  "Title": "Gadget's Replacement",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E23%20Gadget%27s%20Replacement.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E23%20Gadget%27s%20Replacement.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 24,
+                  "Title": "Greenfinger",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E24%20Greenfinger.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E24%20Greenfinger.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 25,
+                  "Title": "Gadget Goes West",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E25%20Gadget%20Goes%20West.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E25%20Gadget%20Goes%20West.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 26,
+                  "Title": "Launch Time",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E26%20Launch%20Time.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E26%20Launch%20Time.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 27,
+                  "Title": "Photo Safari (Black Devil)",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E27%20Photo%20Safari%20%28Black%20Devil%29.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E27%20Photo%20Safari%20%28Black%20Devil%29.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 28,
+                  "Title": "The Coo Coo Clock Caper",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E28%20The%20Coo%20Coo%20Clock%20Caper.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E28%20The%20Coo%20Coo%20Clock%20Caper.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 29,
+                  "Title": "Bermuda Triangle",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E29%20Bermuda%20Triangle.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E29%20Bermuda%20Triangle.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 30,
+                  "Title": "The Japanese Connection",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E30%20The%20Japanese%20Connection.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E30%20The%20Japanese%20Connection.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 31,
+                  "Title": "Arabian Nights",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E31%20Arabian%20Nights.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E31%20Arabian%20Nights.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 32,
+                  "Title": "Clear Case",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E32%20Clear%20Case.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E32%20Clear%20Case.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 33,
+                  "Title": "Dutch Treat",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E33%20Dutch%20Treat.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E33%20Dutch%20Treat.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 34,
+                  "Title": "The Great Divide",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E34%20The%20Great%20Divide.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E34%20The%20Great%20Divide.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 35,
+                  "Title": "Eye of the Dragon",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E35%20Eye%20of%20the%20Dragon.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E35%20Eye%20of%20the%20Dragon.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 36,
+                  "Title": "Doubled Agent",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E36%20Doubled%20Agent.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E36%20Doubled%20Agent.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 37,
+                  "Title": "Plantform of the Opera",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E37%20Plantform%20of%20the%20Opera.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E37%20Plantform%20of%20the%20Opera.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 38,
+                  "Title": "Don't Hold Your Breath",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E38%20Don%27t%20Hold%20Your%20Breath.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E38%20Don%27t%20Hold%20Your%20Breath.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 39,
+                  "Title": "Gone Went the Wind",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E39%20Gone%20Went%20the%20Wind.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E39%20Gone%20Went%20the%20Wind.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 40,
+                  "Title": "King Wrong",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E40%20King%20Wrong.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E40%20King%20Wrong.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 41,
+                  "Title": "Pirate Island",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E41%20Pirate%20Island.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E41%20Pirate%20Island.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 42,
+                  "Title": "M.A.D. Acadamy",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E42%20M.A.D.%20Acadamy.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E42%20M.A.D.%20Acadamy.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 43,
+                  "Title": "No Flies on Us",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E43%20No%20Flies%20on%20Us.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E43%20No%20Flies%20on%20Us.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 44,
+                  "Title": "Luck of the Irish",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E44%20Luck%20of%20the%20Irish.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E44%20Luck%20of%20the%20Irish.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 45,
+                  "Title": "Prince of the Gypsies",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E45%20Prince%20of%20the%20Gypsies.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E45%20Prince%20of%20the%20Gypsies.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 46,
+                  "Title": "Old Man of the Mountain",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E46%20Old%20Man%20of%20the%20Mountain.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E46%20Old%20Man%20of%20the%20Mountain.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 47,
+                  "Title": "The Emerald Duck",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E47%20The%20Emerald%20Duck.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E47%20The%20Emerald%20Duck.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 48,
+                  "Title": "Do Unto Udders",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E48%20Do%20Unto%20Udders.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E48%20Do%20Unto%20Udders.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 49,
+                  "Title": "Did You Myth Me",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E49%20Did%20You%20Myth%20Me.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E49%20Did%20You%20Myth%20Me.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 50,
+                  "Title": "A Bad Altitude",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E50%20A%20Bad%20Altitude.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E50%20A%20Bad%20Altitude.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 51,
+                  "Title": "Funny Money",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E51%20Funny%20Money.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E51%20Funny%20Money.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 52,
+                  "Title": "Follow That Jet",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E52%20Follow%20That%20Jet.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E52%20Follow%20That%20Jet.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 53,
+                  "Title": "Dry Spell",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E53%20Dry%20Spell.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E53%20Dry%20Spell.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 54,
+                  "Title": "Smeldorado",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E54%20Smeldorado.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E54%20Smeldorado.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 55,
+                  "Title": "Quimby Exchange",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E55%20Quimby%20Exchange.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E55%20Quimby%20Exchange.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 56,
+                  "Title": "Weather In Tibet",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E56%20Weather%20In%20Tibet.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E56%20Weather%20In%20Tibet.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 57,
+                  "Title": "Unhenged",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E57%20Unhenged.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E57%20Unhenged.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 58,
+                  "Title": "Snakin' All Over",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E58%20Snakin%27%20All%20Over.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E58%20Snakin%27%20All%20Over.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 59,
+                  "Title": "In Seine",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E59%20In%20Seine.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E59%20In%20Seine.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 60,
+                  "Title": "Tree Guesses",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E60%20Tree%20Guesses.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E60%20Tree%20Guesses.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 61,
+                  "Title": "Birds of a Feather",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E61%20Birds%20of%20a%20Feather.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E61%20Birds%20of%20a%20Feather.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 62,
+                  "Title": "So it is Written",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E62%20So%20it%20is%20Written.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E62%20So%20it%20is%20Written.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 63,
+                  "Title": "Fang the Wonder Dog",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E63%20Fang%20the%20Wonder%20Dog.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E63%20Fang%20the%20Wonder%20Dog.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 64,
+                  "Title": "School for Pickpockets",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E64%20School%20for%20Pickpockets.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E64%20School%20for%20Pickpockets.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 65,
+                  "Title": "Quizz Master",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E65%20Quizz%20Master.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S01E65%20Quizz%20Master.ia.mp4"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Season": 2,
+              "SeasonPoster": "https://movie-fcs.fwh.is/poster/inspector_gadget.jpg",
+              "Episodes": [
+                {
+                  "Episode": 1,
+                  "Title": "Magic Gadget",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E01%20Magic%20Gadget.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E01%20Magic%20Gadget.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 2,
+                  "Title": "The Great Wambini's Seance",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E02%20The%20Great%20Wambini%27s%20Seance.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E02%20The%20Great%20Wambini%27s%20Seance.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 3,
+                  "Title": "Wambini Predicts",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E03%20Wambini%20Predicts.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E03%20Wambini%20Predicts.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 4,
+                  "Title": "The Capeman Cometh",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E04%20The%20Capeman%20Cometh.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E04%20The%20Capeman%20Cometh.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 5,
+                  "Title": "Crashcourse in Crime",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E05%20Crashcourse%20in%20Crime.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E05%20Crashcourse%20in%20Crime.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 6,
+                  "Title": "Gadget's Gadgets",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E06%20Gadget%27s%20Gadgets.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E06%20Gadget%27s%20Gadgets.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 7,
+                  "Title": "Gadget in Minimadness",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E07%20Gadget%20in%20Minimadness.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E07%20Gadget%20in%20Minimadness.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 8,
+                  "Title": "The Incredible Shrinking Gadget",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E08%20The%20Incredible%20Shrinking%20Gadget.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E08%20The%20Incredible%20Shrinking%20Gadget.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 9,
+                  "Title": "Gadget Meets the Grappler",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E09%20Gadget%20Meets%20the%20Grappler.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E09%20Gadget%20Meets%20the%20Grappler.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 10,
+                  "Title": "Ghost Catchers",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E10%20Ghost%20Catchers.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E10%20Ghost%20Catchers.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 11,
+                  "Title": "Busy Signal",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E11%20Busy%20Signal.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E11%20Busy%20Signal.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 12,
+                  "Title": "Bad Dreams are Made of This",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E12%20Bad%20Dreams%20are%20Made%20of%20This.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E12%20Bad%20Dreams%20are%20Made%20of%20This.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 13,
+                  "Title": "Focus on Gadget",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E13%20Focus%20on%20Gadget.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E13%20Focus%20on%20Gadget.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 14,
+                  "Title": "M.A.D. in the Moon",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E14%20M.A.D.%20in%20the%20Moon.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E14%20M.A.D.%20in%20the%20Moon.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 15,
+                  "Title": "N.S.F. Gadget",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E15%20N.S.F.%20Gadget.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E15%20N.S.F.%20Gadget.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 16,
+                  "Title": "Tyrannosaurus Gadget",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E16%20Tyrannosaurus%20Gadget.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E16%20Tyrannosaurus%20Gadget.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 17,
+                  "Title": "Gadget's Roma",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E17%20Gadget%27s%20Roma.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E17%20Gadget%27s%20Roma.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 18,
+                  "Title": "Gadget's Clean Sweep",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E18%20Gadget%27s%20Clean%20Sweep.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E18%20Gadget%27s%20Clean%20Sweep.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 19,
+                  "Title": "Gadget Meets the Clan",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E19%20Gadget%20Meets%20the%20Clan.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E19%20Gadget%20Meets%20the%20Clan.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 20,
+                  "Title": "Gadget and Old Lace",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E20%20Gadget%20and%20Old%20Lace.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E20%20Gadget%20and%20Old%20Lace.ia.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 21,
+                  "Title": "Gadget and the Red Rose",
+                  "Duration": "22m",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "MP4",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E21%20Gadget%20and%20the%20Red%20Rose.mp4"
+                    },
+                    {
+                      "name": "MP4 (alt)",
+                      "subtitle1": "",
+                      "subtitle2": "",
+                      "url": "https://ia800505.us.archive.org/1/items/inspector-gadget-go-go-gadget-series/Inspector%20Gadget%20S02E21%20Gadget%20and%20the%20Red%20Rose.ia.mp4"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Title": "Superman: The Animated Series",
+          "SubCategory": "Animation",
+          "Country": "🇺🇸 United States",
+          "Description": "Superman: The Animated Series is an American television series based on the DC Comics superhero Superman, which was produced by Warner Bros. Animation and originally aired on The WB from 1996 to 2000; lasting 54 episodes.",
+          "Poster": "https://movie-fcs.fwh.is/poster/supermananimatedseries.webp",
+          "Thumbnail": "https://movie-fcs.fwh.is/poster/supermananimatedseries.webp",
+          "Rating": 8.2,
+          "Year": 1996,
+          "Seasons": [
+            {
+              "Season": 1,
+              "SeasonPoster": "",
+              "Episodes": [
+                {
+                  "Episode": 1,
+                  "Title": "The Last Son of Krypton, Part 1",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S01E01%20-%20The%20Last%20Son%20of%20Krypton%2C%20Part%201.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S01E01%20-%20The%20Last%20Son%20of%20Krypton%2C%20Part%201.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 2,
+                  "Title": "The Last Son of Krypton, Part 2",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S01E02%20-%20The%20Last%20Son%20of%20Krypton%2C%20Part%202.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S01E02%20-%20The%20Last%20Son%20of%20Krypton%2C%20Part%202.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 3,
+                  "Title": "The Last Son of Krypton, Part 3",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S01E03%20-%20The%20Last%20Son%20of%20Krypton%2C%20Part%203.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S01E03%20-%20The%20Last%20Son%20of%20Krypton%2C%20Part%203.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 4,
+                  "Title": "Fun and Games",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S01E04%20-%20Fun%20and%20Games%20.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S01E04%20-%20Fun%20and%20Games%20.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 5,
+                  "Title": "A Little Piece of Home",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S01E05%20-%20A%20Little%20Piece%20of%20Home.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S01E05%20-%20A%20Little%20Piece%20of%20Home.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 6,
+                  "Title": "Feeding Time",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S01E06%20-%20Feeding%20Time.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S01E06%20-%20Feeding%20Time.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 7,
+                  "Title": "The Way of All Flesh",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S01E07%20-%20The%20Way%20of%20All%20Flesh.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S01E07%20-%20The%20Way%20of%20All%20Flesh.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 8,
+                  "Title": "Stolen Memories",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S01E08%20-%20Stolen%20Memories.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S01E08%20-%20Stolen%20Memories.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 9,
+                  "Title": "The Main Man, Part 1",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S01E09%20-%20The%20Main%20Man%2C%20Part%201.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S01E09%20-%20The%20Main%20Man%2C%20Part%201.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 10,
+                  "Title": "The Main Man, Part 2",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S01E10%20-%20The%20Main%20Man%2C%20%20Part%202.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S01E10%20-%20The%20Main%20Man%2C%20%20Part%202.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 11,
+                  "Title": "My Girl",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S01E11%20-%20My%20Girl.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S01E11%20-%20My%20Girl.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 12,
+                  "Title": "Tools of the Trade",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S01E12%20-%20Tools%20of%20the%20Trade.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S01E12%20-%20Tools%20of%20the%20Trade.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 13,
+                  "Title": "Two's a Crowd",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S01E13%20-%20Two%27s%20a%20Crowd%20.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S01E13%20-%20Two%27s%20a%20Crowd%20.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Season": 2,
+              "SeasonPoster": "https://movie-fcs.fwh.is/poster/7lhG7XSz0VkbUtXoXtUVdjDrUx6.webp",
+              "Episodes": [
+                {
+                  "Episode": 1,
+                  "Title": "Blasts From the Past, Part 1",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E01%20-%20Blasts%20From%20the%20Past%2C%20Part%201.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E01%20-%20Blasts%20From%20the%20Past%2C%20Part%201.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 2,
+                  "Title": "Blasts From the Past, Part 2",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E02%20-%20Blasts%20From%20the%20Past%2C%20Part%202.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E02%20-%20Blasts%20From%20the%20Past%2C%20Part%202.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 3,
+                  "Title": "The Prometheon",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E03%20-%20The%20Prometheon.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E03%20-%20The%20Prometheon.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 4,
+                  "Title": "Speed Demons",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E04%20-%20Speed%20Demons.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E04%20-%20Speed%20Demons.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 5,
+                  "Title": "Livewire",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E05%20-%20Livewire.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E05%20-%20Livewire.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 6,
+                  "Title": "Identity Crisis",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E06%20-%20Identity%20Crisis.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E06%20-%20Identity%20Crisis.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 7,
+                  "Title": "Target",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E07%20-%20Target.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E07%20-%20Target.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 8,
+                  "Title": "Mxyzpixilated",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E08%20-%20Mxyzpixilated.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E08%20-%20Mxyzpixilated.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 9,
+                  "Title": "Action Figures",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E09%20-%20Action%20Figures.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E09%20-%20Action%20Figures.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 10,
+                  "Title": "Double Dose",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E10%20-%20Double%20Dose.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E10%20-%20Double%20Dose.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 11,
+                  "Title": "Solar Power",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E11%20-%20Solar%20Power.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E11%20-%20Solar%20Power.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 12,
+                  "Title": "Brave New Metropolis",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E12%20-%20Brave%20New%20Metropolis.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E12%20-%20Brave%20New%20Metropolis.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 13,
+                  "Title": "Monkey Fun",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E13%20-%20Monkey%20Fun.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E13%20-%20Monkey%20Fun.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 14,
+                  "Title": "Ghost in the Machine",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E14%20-%20Ghost%20in%20the%20Machine.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E14%20-%20Ghost%20in%20the%20Machine.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 15,
+                  "Title": "Father's Day",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E15%20-%20Father%27s%20Day.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E15%20-%20Father%27s%20Day.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 16,
+                  "Title": "World's Finest, Part 1",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E16%20-%20World%27s%20Finest%2C%20Part%201.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E16%20-%20World%27s%20Finest%2C%20Part%201.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 17,
+                  "Title": "World's Finest, Part 2",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E17%20-%20World%27s%20Finest%2C%20Part%202.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E17%20-%20World%27s%20Finest%2C%20Part%202.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 18,
+                  "Title": "World's Finest, Part 3",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E18%20-%20World%27s%20Finest%2C%20Part%203.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E18%20-%20World%27s%20Finest%2C%20Part%203.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 19,
+                  "Title": "The Hand of Fate",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E19%20-%20The%20Hand%20of%20Fate.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E19%20-%20The%20Hand%20of%20Fate.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 20,
+                  "Title": "Bizarro's World",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E20%20-%20Bizarro%27s%20World.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E20%20-%20Bizarro%27s%20World.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 21,
+                  "Title": "Prototype",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E21%20-%20Prototype.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E21%20-%20Prototype.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 22,
+                  "Title": "The Late Mr. Kent",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E22%20-%20The%20Late%20Mr.%20Kent.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E22%20-%20The%20Late%20Mr.%20Kent.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 23,
+                  "Title": "Heavy Metal",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E23%20-%20Heavy%20Metal.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E23%20-%20Heavy%20Metal.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 24,
+                  "Title": "Warrior Queen",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E24%20-%20Warrior%20Queen.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E24%20-%20Warrior%20Queen.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 25,
+                  "Title": "Apokolips...Now!, Part 1",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E25%20-%20Apokolips...Now%21%2C%20Part%201.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E25%20-%20Apokolips...Now%21%2C%20Part%201.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 26,
+                  "Title": "Apokolips...Now!, Part 2",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E26%20-%20Apokolips...Now%2C%20Part%202.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E26%20-%20Apokolips...Now%2C%20Part%202.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 27,
+                  "Title": "Little Girl Lost, Part 1",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E27%20-%20Little%20Girl%20Lost%2C%20Part%201.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E27%20-%20Little%20Girl%20Lost%2C%20Part%201.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 28,
+                  "Title": "Little Girl Lost, Part 2",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E28%20-%20Little%20Girl%20Lost%2C%20Part%201.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S02E28%20-%20Little%20Girl%20Lost%2C%20Part%201.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Season": 3,
+              "SeasonPoster": "https://movie-fcs.fwh.is/poster/supermananimatedseries",
+              "Episodes": [
+                {
+                  "Episode": 1,
+                  "Title": "Where There's Smoke",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S03E01%20-%20Where%20There%27s%20Smoke.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S03E01%20-%20Where%20There%27s%20Smoke.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 2,
+                  "Title": "Knight Time",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S03E02%20-%20Knight%20Time.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S03E02%20-%20Knight%20Time.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 3,
+                  "Title": "New Kids in Town",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S03E03%20-%20New%20Kids%20in%20Town.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S03E03%20-%20New%20Kids%20in%20Town.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 4,
+                  "Title": "Obsession",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S03E04%20-%20Obsession.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S03E04%20-%20Obsession.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 5,
+                  "Title": "Little Big Head Man",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S03E05%20-%20Little%20Head%20Big%20Man.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S03E05%20-%20Little%20Head%20Big%20Man.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 6,
+                  "Title": "Absolute Power",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S03E06%20-%20Absolute%20Power.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S03E06%20-%20Absolute%20Power.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 7,
+                  "Title": "In Brightest Day...",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S03E07%20-%20In%20Brightest%20Day.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S03E07%20-%20In%20Brightest%20Day.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 8,
+                  "Title": "Superman's Pal",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S03E08%20-%20Superman%27s%20Pal.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S03E08%20-%20Superman%27s%20Pal.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 9,
+                  "Title": "A Fish Story",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S03E09%20-%20A%20Fish%20Story.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S03E09%20-%20A%20Fish%20Story.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 10,
+                  "Title": "Unity",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S03E10%20-%20Unity.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S03E10%20-%20Unity.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Season": 4,
+              "SeasonPoster": "https://movie-fcs.fwh.is/poster/supermananimatedseries",
+              "Episodes": [
+                {
+                  "Episode": 1,
+                  "Title": "The Demon Reborn",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S04E01%20-%20The%20Demon%20Reborn.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S04E01%20-%20The%20Demon%20Reborn.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 2,
+                  "Title": "Legacy, Part 1",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S04E02%20-%20Legacy%2C%20Part%201.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S04E02%20-%20Legacy%2C%20Part%201.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                },
+                {
+                  "Episode": 3,
+                  "Title": "Legacy, Part 2",
+                  "Duration": "21 min",
+                  "Description": "",
+                  "Thumbnail": "",
+                  "Servers": [
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S04E03%20-%20Legacy%2C%20Part%202.mp4",
+                      "subtitle": []
+                    },
+                    {
+                      "name": "720p",
+                      "url": "https://dn720309.ca.archive.org/0/items/s-01-e-04-fun-and-games/S04E03%20-%20Legacy%2C%20Part%202.ia.mp4",
+                      "subtitle": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Add DRM key and ID to the TV5 MPD entry in `playlist.json` to enable playback of the DRM-protected stream.

---
<a href="https://cursor.com/background-agent?bcId=bc-6d8549a8-eb85-47c4-9dd9-2faaf634f868">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6d8549a8-eb85-47c4-9dd9-2faaf634f868">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>