### PR TITLE
Debug mpd playback error with key and id

### DIFF
--- a/CineCraze/app/src/main/assets/shaka_player.html
+++ b/CineCraze/app/src/main/assets/shaka_player.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Shaka Player Fallback</title>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/shaka-player/4.3.5/shaka-player.compiled.js"></script>
+  <style>
+    html, body { height: 100%; margin: 0; background: #000; }
+    #video { width: 100vw; height: 100vh; background: #000; }
+  </style>
+</head>
+<body>
+  <video id="video" controls autoplay></video>
+  <script>
+    function getQueryParam(name) {
+      const url = new URL(window.location.href);
+      return url.searchParams.get(name);
+    }
+    const manifestUri = getQueryParam('url');
+    const kid = getQueryParam('kid');
+    const key = getQueryParam('key');
+    async function initApp() {
+      const video = document.getElementById('video');
+      const player = new shaka.Player(video);
+      if (kid && key) {
+        const clearkeys = {};
+        // Convert KID to base64
+        function hexToBase64(hex) {
+          return btoa(hex.match(/.{1,2}/g).map(byte => String.fromCharCode(parseInt(byte, 16))).join(''));
+        }
+        clearkeys[hexToBase64(kid)] = hexToBase64(key);
+        player.configure({
+          drm: {
+            clearKeys: clearkeys
+          }
+        });
+      }
+      try {
+        await player.load(manifestUri);
+      } catch (e) {
+        video.style.display = 'none';
+        document.body.innerHTML += '<div style="color:white;text-align:center;margin-top:2em;">Playback Error: ' + e + '</div>';
+      }
+    }
+    document.addEventListener('DOMContentLoaded', initApp);
+  </script>
+</body>
+</html>

--- a/CineCraze/app/src/main/res/layout/activity_details.xml
+++ b/CineCraze/app/src/main/res/layout/activity_details.xml
@@ -29,6 +29,12 @@
                 app:resize_mode="fit"
                 app:surface_type="texture_view" />
 
+            <WebView
+                android:id="@+id/webview_player"
+                android:layout_width="match_parent"
+                android:layout_height="250dp"
+                android:visibility="gone" />
+
             <androidx.appcompat.widget.Toolbar
                 android:id="@+id/toolbar"
                 android:layout_width="match_parent"


### PR DESCRIPTION
Implement a fallback to Shaka Player in WebView for DRM streams that ExoPlayer cannot play with provided keys.

---
<a href="https://cursor.com/background-agent?bcId=bc-79fdc359-fd60-4ef3-a881-dda9a78b14af">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-79fdc359-fd60-4ef3-a881-dda9a78b14af">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>